### PR TITLE
rel-03: promote replace to stable contract

### DIFF
--- a/docs/diamond-suite.md
+++ b/docs/diamond-suite.md
@@ -36,8 +36,6 @@ Stable:
 - `table [--] [FILE...]`
 - `count [--] [FILE...]`
 - `filter EXPR [--] [FILE...]`
-
-Preview:
 - `replace [--literal] PATTERN REPLACEMENT [--] [FILE...]`
 
 ## Exit Codes (All Tools)

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -107,12 +107,13 @@ No other exit codes are permitted.
 - table
 - count
 - filter
+- replace
 
 Stable builtins guarantee CLI/output/exit compatibility unless versioned.
 
 ### 3.2 Preview
 
-- replace
+None.
 
 Preview builtins are functional but may evolve before stabilization.
 

--- a/progress.yaml
+++ b/progress.yaml
@@ -4,13 +4,13 @@ project:
   status: active
 
 snapshot:
-  updated_utc: '2026-03-05T21:36:06Z'
+  updated_utc: '2026-03-05T21:47:11Z'
   git:
-    branch: main
-    head: 'aea5d0a'
+    branch: rel-03-promote-replace-stable
+    head: '9753494'
   window:
-    completed: 14
-    pending: 3
+    completed: 15
+    pending: 2
   basis:
     - docs/project-spec.md (normative contract + builtin inventory)
     - docs/diamond-suite.md (handbook + usage examples)
@@ -164,6 +164,20 @@ completed:
     evidence:
       - README.md
 
+  - id: rel-03
+    category: feature
+    title: Promote replace from Preview to Stable once contract and tests are finalized
+    branch: rel-03-promote-replace-stable
+    state: complete
+    spec_refs:
+      - docs/project-spec.md#3-1-stable-v1-0-contract
+      - docs/project-spec.md#3-2-preview
+    evidence:
+      - docs/project-spec.md
+      - docs/diamond-suite.md
+      - tests/spec_inventory.bats
+      - tests/replace.bats
+
   - id: cli-02
     category: docs
     title: Document positional-primary CLI defaults consistently across per-builtin docs
@@ -186,18 +200,6 @@ completed:
       - .github/workflows/ci.yml
 
 pending:
-  - id: rel-03
-    category: feature
-    title: Promote replace from Preview to Stable once contract and tests are finalized
-    branch: tbd
-    state: pending
-    spec_refs:
-      - docs/project-spec.md#3-2-preview
-    rationale:
-      - replace is implemented with tests/docs, but contract still marks it Preview.
-    depends_on:
-      - rel-01
-
   - id: pkg-01
     category: chore
     title: Add release packaging target for distributing builtins and docs

--- a/tests/replace.bats
+++ b/tests/replace.bats
@@ -33,6 +33,22 @@
   [ "$status" -eq 2 ]
 }
 
+@test "replace: duplicate --literal is usage error (exit 2)" {
+  run bash -c '
+    enable -f "$BASH_BUILTINS_DIR/replace.debug.so" replace
+    printf "a\n" | replace --literal --literal a x
+  '
+  [ "$status" -eq 2 ]
+}
+
+@test "replace: invalid regex is runtime error (exit 2)" {
+  run bash -c '
+    enable -f "$BASH_BUILTINS_DIR/replace.debug.so" replace
+    printf "a\n" | replace "[" x
+  '
+  [ "$status" -eq 2 ]
+}
+
 @test "replace: literal mode basic replacement" {
   run bash -c '
     enable -f "$BASH_BUILTINS_DIR/replace.debug.so" replace

--- a/tests/spec_inventory.bats
+++ b/tests/spec_inventory.bats
@@ -11,15 +11,23 @@
         in_section && /^- / { sub(/^- /, "", $0); print }
       '"'"' docs/project-spec.md
     )"
-    expected=$'"'"'lines\nfields\nmatch\ntake\ntrim\ntable\ncount\nfilter'"'"'
+    expected=$'"'"'lines\nfields\nmatch\ntake\ntrim\ntable\ncount\nfilter\nreplace'"'"'
     [ "$actual" = "$expected" ]
   '
   [ "$status" -eq 0 ]
 }
 
-@test "spec inventory: no planned builtins and non-contract implemented list is explicit" {
+@test "spec inventory: preview/planned/non-contract sections are explicit none" {
   run bash -c '
     set -euo pipefail
+    preview_body="$(awk '"'"'
+      /^### 3\.2 Preview$/ { in_section=1; next }
+      in_section && /^### / { in_section=0 }
+      in_section { print }
+    '"'"' docs/project-spec.md)"
+    printf "%s\n" "$preview_body" | grep -qx "None."
+    ! printf "%s\n" "$preview_body" | grep -q "^- "
+
     planned_body="$(awk '"'"'
       /^### 3\.3 Planned$/ { in_section=1; next }
       in_section && /^### / { in_section=0 }


### PR DESCRIPTION
Promotes replace from Preview to  Stable in the normative spec, syncs handbook inventory, updated spec inventory conformance tests, adds replace failure-case tests and marks rel-03 complete in progress.yaml