### PR TITLE
[codex] Add cppcheck and split CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  conformance:
-    name: Build and Test
+  lint:
+    name: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -20,9 +20,6 @@ jobs:
           set -euxo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            bats \
-            bash-builtins \
-            build-essential \
             clang-format \
             shellcheck
 
@@ -39,11 +36,66 @@ jobs:
       - name: Run format check
         run: make format-check
 
-      - name: Run conformance tests
+  static-analysis:
+    name: static-analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cppcheck
+
+      - name: Run cppcheck
+        run: make cppcheck
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bats \
+            bash-builtins \
+            build-essential
+
+      - name: Run tests
         run: |
           set -euxo pipefail
           test -d /usr/include/bash
           make test BASH_SRC=/usr/include/bash
+
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - static-analysis
+      - test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bash-builtins \
+            build-essential
 
       - name: Build release bundle
         run: |

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DIST_SHA256 := $(DIST_TARBALL).sha256
 CC   ?= cc
 BASH ?= bash
 CLANG_FORMAT ?= clang-format
+CPPCHECK ?= cppcheck
 
 # Point at a Bash source tree for headers (recommended)
 # Override: make BASH_SRC=/home/opsman/bash
@@ -49,7 +50,7 @@ CORE_REL_OBJS := $(patsubst $(SRC_DIR)/diamondcore/%.c,$(REL_OBJDIR)/core/%.o,$(
 # All C/C++ headers and sources under src/
 FORMAT_SRCS := $(shell find $(SRC_DIR) -type f \( -name '*.c' -o -name '*.h' \))
 
-.PHONY: all debug rel dist dist-clean clean test list-builtins format format-check
+.PHONY: all debug rel dist dist-clean clean test list-builtins format format-check cppcheck lint-c
 
 all: debug
 
@@ -110,6 +111,21 @@ format:
 format-check:
 	@echo "Checking formatting..."
 	@$(CLANG_FORMAT) --dry-run --Werror $(FORMAT_SRCS)
+
+cppcheck:
+	@echo "Running cppcheck..."
+	@$(CPPCHECK) \
+		--quiet \
+		--error-exitcode=2 \
+		--language=c \
+		--std=c11 \
+		--enable=warning,performance,portability \
+		--suppress=missingIncludeSystem \
+		-I$(INCLUDE_DIR) \
+		-I$(SRC_DIR)/builtins \
+		$(SRC_DIR)
+
+lint-c: cppcheck
 
 # -----------------------------
 

--- a/src/diamondcore/range.c
+++ b/src/diamondcore/range.c
@@ -51,6 +51,11 @@ static bool add_range(dc_sel_t *sel, uint64_t a, uint64_t b, dc_error_t *err) {
  * - must fit uint64_t
  */
 static bool parse_uint_strict(const char **p, uint64_t *out, dc_error_t *err) {
+  if (!p || !*p) {
+    dc_err_set(err, DC_ERR_USAGE, "lines: invalid SPEC");
+    return false;
+  }
+
   const char *s = *p;
   if (!s || !*s) {
     dc_err_set(err, DC_ERR_USAGE, "lines: invalid SPEC");
@@ -83,6 +88,8 @@ static bool parse_uint_strict(const char **p, uint64_t *out, dc_error_t *err) {
 }
 
 static bool match_dots(const char **p) {
+  if (!p || !*p) return false;
+
   const char *s = *p;
   if (s && s[0] == '.' && s[1] == '.') {
     *p = s + 2;

--- a/tests/lines.bats
+++ b/tests/lines.bats
@@ -40,6 +40,13 @@ bash_with_lines() {
   [ "$status" -eq 2 ]
 }
 
+@test "lines: usage error on bare open-start range" {
+  printf "a\nb\n" >"$F1"
+
+  run bash_with_lines "lines .. '$F1'"
+  [ "$status" -eq 2 ]
+}
+
 @test "lines: select single line" {
   printf "a\nb\nc\n" >"$F1"
 


### PR DESCRIPTION
## Summary
- split the CI workflow into readable `lint`, `static-analysis`, `test`, and `package` jobs
- add a reusable `make cppcheck` target and wire it into CI with conservative project-specific settings
- harden the shared range parser helpers against null cursor paths and add a regression test

## Why
The original CI job mixed linting, testing, and packaging in one place. This change keeps the workflow simple for a solo-maintained C project while making failures easier to isolate. Adding `cppcheck` also surfaced a real defensive bug in the range parser helpers, so the PR fixes that path and locks it with a test.

## Impact
- CI output is easier to read and debug by job
- static analysis runs in CI and locally through `make cppcheck`
- no intended change to builtin CLI, streaming, or exit-code contract

## Validation
- `make cppcheck`
- `make test`
