### PR TITLE
[codex] normalize clang-format baseline

### DIFF
--- a/src/builtins/builtin_count.c
+++ b/src/builtins/builtin_count.c
@@ -4,34 +4,38 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>
 
 // Bash loadable builtin headers
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *count_shortdoc = "count [--] [FILE...]";
+__attribute__((unused)) static const char *count_shortdoc =
+    "count [--] [FILE...]";
 
 static char *count_doc[] = {
-  "Count input lines.",
-  (char *)0,
+    "Count input lines.",
+    (char *)0,
 };
 
 static int count_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "count: %s\n", msg);
-  else dc_print_usage_count(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "count: %s\n", msg);
+  else
+    dc_print_usage_count(stderr);
   return 2;
 }
 
 static int count_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "count: %s\n", msg);
-  else fprintf(stderr, "count: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "count: %s\n", msg);
+  else
+    fprintf(stderr, "count: I/O error\n");
   return 2;
 }
 
@@ -74,8 +78,7 @@ static int count_main(char *const *files, size_t file_count) {
   return 0;
 }
 
-__attribute__((visibility("default")))
-int count_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int count_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
@@ -95,7 +98,8 @@ int count_builtin(WORD_LIST *list) {
   // === ANCHOR:ARGV-PARSE-BEGIN ===
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!end_opts && strcmp(tok, "--help") == 0) {
       rc = count_help();
@@ -136,12 +140,11 @@ out:
   // === ANCHOR:CLEANUP-END ===
 }
 
-__attribute__((visibility("default")))
-struct builtin count_struct = {
-  .name = "count",
-  .function = count_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = count_doc,
-  .short_doc = (char *)"count [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin count_struct = {
+    .name = "count",
+    .function = count_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = count_doc,
+    .short_doc = (char *)"count [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_fields.c
+++ b/src/builtins/builtin_fields.c
@@ -2,35 +2,39 @@
 
 #include "diamondcore.h"
 
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>
 
 // Bash loadable builtin headers (vendored minimal subset for loadables)
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *fields_shortdoc = "fields SPEC [FILE...]";
+__attribute__((unused)) static const char *fields_shortdoc =
+    "fields SPEC [FILE...]";
 
 static char *fields_doc[] = {
-  "Select and emit specific 1-based fields from each input line.",
-  (char *)0,
+    "Select and emit specific 1-based fields from each input line.",
+    (char *)0,
 };
 
 // === ANCHOR:ERROR-HELPERS-BEGIN ===
 static int fields_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "fields: %s\n", msg);
-  else dc_print_usage_fields(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "fields: %s\n", msg);
+  else
+    dc_print_usage_fields(stderr);
   return 2;
 }
 
 static int fields_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "fields: %s\n", msg);
-  else fprintf(stderr, "fields: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "fields: %s\n", msg);
+  else
+    fprintf(stderr, "fields: I/O error\n");
   return 2;
 }
 
@@ -75,7 +79,8 @@ static int fields_main(const char *spec, bool delim_mode, uint8_t delim,
 
     const uint8_t *line = v.ptr;
     size_t linelen = v.len;
-    if (v.ends_with_nl && linelen > 0) linelen--; // newline is not part of any field
+    if (v.ends_with_nl && linelen > 0)
+      linelen--; // newline is not part of any field
 
     dc_field_view_t *fields = NULL;
     size_t nfields = 0;
@@ -101,11 +106,13 @@ static int fields_main(const char *spec, bool delim_mode, uint8_t delim,
     bool first = true;
 
     size_t limit = nfields;
-    if (has_max && max_finite < (uint64_t)limit) limit = (size_t)max_finite;
+    if (has_max && max_finite < (uint64_t)limit)
+      limit = (size_t)max_finite;
 
     for (size_t i = 0; i < limit; i++) {
       uint64_t idx = (uint64_t)(i + 1);
-      if (!dc_sel_wants(sel, idx)) continue;
+      if (!dc_sel_wants(sel, idx))
+        continue;
 
       if (!first) {
         if (fputc(join_ch, stdout) == EOF) {
@@ -159,13 +166,14 @@ static int fields_main(const char *spec, bool delim_mode, uint8_t delim,
 // === ANCHOR:CORE-MAIN-END ===
 
 // Parsing rules:
-// - Only --help, --tsv and -d DELIM are recognized (before SPEC, unless after --).
+// - Only --help, --tsv and -d DELIM are recognized (before SPEC, unless after
+// --).
 // - Any other -x token is an error unless after --, or token is exactly '-'.
 // - SPEC is required and is the first non-option token.
-__attribute__((visibility("default")))
-int fields_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int fields_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
-  // Ignore SIGPIPE so write failures show up as EPIPE/stdio errors and we return 2.
+  // Ignore SIGPIPE so write failures show up as EPIPE/stdio errors and we
+  // return 2.
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
 
@@ -190,7 +198,8 @@ int fields_builtin(WORD_LIST *list) {
   // === ANCHOR:ARGV-PARSE-BEGIN ===
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!spec) {
       if (!end_opts && strcmp(tok, "--help") == 0) {
@@ -223,7 +232,8 @@ int fields_builtin(WORD_LIST *list) {
           }
           w = w->next;
           darg = w->word->word;
-          if (!darg) darg = "";
+          if (!darg)
+            darg = "";
         }
 
         if (delim_mode) {
@@ -240,7 +250,8 @@ int fields_builtin(WORD_LIST *list) {
         continue;
       }
 
-      if (!end_opts && tok[0] == '-' && tok[1] != '\0' && strcmp(tok, "-") != 0) {
+      if (!end_opts && tok[0] == '-' && tok[1] != '\0' &&
+          strcmp(tok, "-") != 0) {
         rc = fields_usage_err("unknown option (use --help)");
         goto out;
       }
@@ -288,12 +299,11 @@ out:
   // === ANCHOR:CLEANUP-END ===
 }
 
-__attribute__((visibility("default")))
-struct builtin fields_struct = {
-  .name = "fields",
-  .function = fields_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = fields_doc,
-  .short_doc = (char *)"fields SPEC [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin fields_struct = {
+    .name = "fields",
+    .function = fields_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = fields_doc,
+    .short_doc = (char *)"fields SPEC [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_filter.c
+++ b/src/builtins/builtin_filter.c
@@ -2,22 +2,22 @@
 
 #include "diamondcore.h"
 
+#include <signal.h> // ANCHOR:SIGPIPE-INCLUDE
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>  // ANCHOR:SIGPIPE-INCLUDE
 
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *filter_shortdoc = "filter EXPR [--] [FILE...]";
+__attribute__((unused)) static const char *filter_shortdoc =
+    "filter EXPR [--] [FILE...]";
 
 static char *filter_doc[] = {
-  "Select input lines whose fields satisfy a constrained boolean expression.",
-  (char *)0,
+    "Select input lines whose fields satisfy a constrained boolean expression.",
+    (char *)0,
 };
 
 /* =============================================================================
@@ -26,14 +26,18 @@ static char *filter_doc[] = {
  */
 
 static int filter_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "filter: %s\n", msg);
-  else dc_print_usage_filter(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "filter: %s\n", msg);
+  else
+    dc_print_usage_filter(stderr);
   return 2;
 }
 
 static int filter_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "filter: %s\n", msg);
-  else fprintf(stderr, "filter: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "filter: %s\n", msg);
+  else
+    fprintf(stderr, "filter: I/O error\n");
   return 2;
 }
 
@@ -69,9 +73,9 @@ typedef struct {
   enum tok_type t;
   const char *start;
   size_t len;
-  uint64_t u64;   /* for TOK_FIELD */
-  int64_t i64;    /* for TOK_INT */
-  char *owned;    /* for TOK_STR (unescaped), and TOK_INT (lexeme copy) */
+  uint64_t u64; /* for TOK_FIELD */
+  int64_t i64;  /* for TOK_INT */
+  char *owned;  /* for TOK_STR (unescaped), and TOK_INT (lexeme copy) */
   size_t owned_len;
 } tok_t;
 
@@ -84,8 +88,10 @@ typedef struct {
 } lexer_t;
 
 static bool lex_err(lexer_t *lx, const char *msg) {
-  if (!lx) return false;
-  snprintf(lx->err, sizeof(lx->err), "%s", msg ? msg : "expression parse error");
+  if (!lx)
+    return false;
+  snprintf(lx->err, sizeof(lx->err), "%s",
+           msg ? msg : "expression parse error");
   return false;
 }
 
@@ -94,30 +100,38 @@ static inline bool is_ws_ch(unsigned char c) {
           c == '\f');
 }
 
-static inline bool is_digit_ch(unsigned char c) { return (c >= '0' && c <= '9'); }
+static inline bool is_digit_ch(unsigned char c) {
+  return (c >= '0' && c <= '9');
+}
 
 static bool parse_i64_bytes(const uint8_t *p, size_t n, int64_t *out) {
-  if (!p || n == 0 || !out) return false;
+  if (!p || n == 0 || !out)
+    return false;
   size_t i = 0;
   bool neg = false;
   if (p[i] == '-') {
     neg = true;
     i++;
-    if (i >= n) return false;
+    if (i >= n)
+      return false;
   }
   uint64_t acc = 0;
   for (; i < n; i++) {
-    if (!is_digit_ch((unsigned char)p[i])) return false;
+    if (!is_digit_ch((unsigned char)p[i]))
+      return false;
     uint64_t d = (uint64_t)(p[i] - '0');
-    if (acc > UINT64_MAX / 10ULL) return false;
+    if (acc > UINT64_MAX / 10ULL)
+      return false;
     acc *= 10ULL;
-    if (acc > UINT64_MAX - d) return false;
+    if (acc > UINT64_MAX - d)
+      return false;
     acc += d;
   }
 
   if (neg) {
     /* Allow INT64_MIN exactly: magnitude 9223372036854775808 */
-    if (acc > (uint64_t)INT64_MAX + 1ULL) return false;
+    if (acc > (uint64_t)INT64_MAX + 1ULL)
+      return false;
     if (acc == (uint64_t)INT64_MAX + 1ULL) {
       *out = INT64_MIN;
       return true;
@@ -126,45 +140,56 @@ static bool parse_i64_bytes(const uint8_t *p, size_t n, int64_t *out) {
     return true;
   }
 
-  if (acc > (uint64_t)INT64_MAX) return false;
+  if (acc > (uint64_t)INT64_MAX)
+    return false;
   *out = (int64_t)acc;
   return true;
 }
 
 static bool parse_i64_cstr(const char *s, int64_t *out) {
-  if (!s) return false;
+  if (!s)
+    return false;
   return parse_i64_bytes((const uint8_t *)s, strlen(s), out);
 }
 
-static int bytes_cmp(const uint8_t *a, size_t alen, const uint8_t *b, size_t blen) {
+static int bytes_cmp(const uint8_t *a, size_t alen, const uint8_t *b,
+                     size_t blen) {
   size_t n = (alen < blen) ? alen : blen;
   for (size_t i = 0; i < n; i++) {
     unsigned int av = (unsigned int)a[i];
     unsigned int bv = (unsigned int)b[i];
-    if (av < bv) return -1;
-    if (av > bv) return 1;
+    if (av < bv)
+      return -1;
+    if (av > bv)
+      return 1;
   }
-  if (alen < blen) return -1;
-  if (alen > blen) return 1;
+  if (alen < blen)
+    return -1;
+  if (alen > blen)
+    return 1;
   return 0;
 }
 
 static void tok_free(tok_t *t) {
-  if (!t) return;
+  if (!t)
+    return;
   free(t->owned);
   t->owned = NULL;
   t->owned_len = 0;
 }
 
 static bool lex_next(lexer_t *lx, tok_t *out) {
-  if (!lx || !out) return false;
+  if (!lx || !out)
+    return false;
   memset(out, 0, sizeof(*out));
   out->t = TOK_EOF;
 
   /* limits */
-  if (lx->token_count >= 2048) return lex_err(lx, "expression too complex");
+  if (lx->token_count >= 2048)
+    return lex_err(lx, "expression too complex");
 
-  while (lx->i < lx->len && is_ws_ch((unsigned char)lx->s[lx->i])) lx->i++;
+  while (lx->i < lx->len && is_ws_ch((unsigned char)lx->s[lx->i]))
+    lx->i++;
   if (lx->i >= lx->len) {
     out->t = TOK_EOF;
     lx->token_count++;
@@ -228,59 +253,63 @@ static bool lex_next(lexer_t *lx, tok_t *out) {
 
   /* One-char tokens */
   switch (p[0]) {
-    case '(':
-      out->t = TOK_LPAREN;
-      out->start = p;
-      out->len = 1;
-      lx->i += 1;
-      lx->token_count++;
-      return true;
-    case ')':
-      out->t = TOK_RPAREN;
-      out->start = p;
-      out->len = 1;
-      lx->i += 1;
-      lx->token_count++;
-      return true;
-    case '!':
-      out->t = TOK_NOT;
-      out->start = p;
-      out->len = 1;
-      lx->i += 1;
-      lx->token_count++;
-      return true;
-    case '<':
-      out->t = TOK_LT;
-      out->start = p;
-      out->len = 1;
-      lx->i += 1;
-      lx->token_count++;
-      return true;
-    case '>':
-      out->t = TOK_GT;
-      out->start = p;
-      out->len = 1;
-      lx->i += 1;
-      lx->token_count++;
-      return true;
-    default:
-      break;
+  case '(':
+    out->t = TOK_LPAREN;
+    out->start = p;
+    out->len = 1;
+    lx->i += 1;
+    lx->token_count++;
+    return true;
+  case ')':
+    out->t = TOK_RPAREN;
+    out->start = p;
+    out->len = 1;
+    lx->i += 1;
+    lx->token_count++;
+    return true;
+  case '!':
+    out->t = TOK_NOT;
+    out->start = p;
+    out->len = 1;
+    lx->i += 1;
+    lx->token_count++;
+    return true;
+  case '<':
+    out->t = TOK_LT;
+    out->start = p;
+    out->len = 1;
+    lx->i += 1;
+    lx->token_count++;
+    return true;
+  case '>':
+    out->t = TOK_GT;
+    out->start = p;
+    out->len = 1;
+    lx->i += 1;
+    lx->token_count++;
+    return true;
+  default:
+    break;
   }
 
   /* Field reference: $<digits> (must be >0) */
   if (p[0] == '$') {
-    if (rem < 2 || !is_digit_ch((unsigned char)p[1])) return lex_err(lx, "invalid field reference");
+    if (rem < 2 || !is_digit_ch((unsigned char)p[1]))
+      return lex_err(lx, "invalid field reference");
     size_t j = 1;
     uint64_t v = 0;
     while (j < rem && is_digit_ch((unsigned char)p[j])) {
       uint64_t d = (uint64_t)(p[j] - '0');
-      if (v > UINT64_MAX / 10ULL) return lex_err(lx, "field index overflow");
+      if (v > UINT64_MAX / 10ULL)
+        return lex_err(lx, "field index overflow");
       v *= 10ULL;
-      if (v > UINT64_MAX - d) return lex_err(lx, "field index overflow");
+      if (v > UINT64_MAX - d)
+        return lex_err(lx, "field index overflow");
       v += d;
       j++;
     }
-    if (v == 0) return lex_err(lx, "$0 is invalid");
+    if (v == 0)
+      return lex_err(lx, "$0 is invalid");
     out->t = TOK_FIELD;
     out->start = p;
     out->len = j;
@@ -350,11 +379,14 @@ static bool lex_next(lexer_t *lx, tok_t *out) {
     size_t j = 0;
     if (p[0] == '-') {
       j++;
-      if (j >= rem || !is_digit_ch((unsigned char)p[j])) return lex_err(lx, "invalid integer literal");
+      if (j >= rem || !is_digit_ch((unsigned char)p[j]))
+        return lex_err(lx, "invalid integer literal");
     }
-    while (j < rem && is_digit_ch((unsigned char)p[j])) j++;
+    while (j < rem && is_digit_ch((unsigned char)p[j]))
+      j++;
     char *lex = (char *)malloc(j + 1);
-    if (!lex) return lex_err(lx, "out of memory");
+    if (!lex)
+      return lex_err(lx, "out of memory");
     memcpy(lex, p, j);
     lex[j] = '\0';
     int64_t iv = 0;
@@ -413,14 +445,16 @@ typedef struct {
 } parser_t;
 
 static void operand_free(operand_t *o) {
-  if (!o) return;
+  if (!o)
+    return;
   free(o->s);
   o->s = NULL;
   o->slen = 0;
 }
 
 static void node_free(node_t *n) {
-  if (!n) return;
+  if (!n)
+    return;
   if (n->t == N_AND || n->t == N_OR || n->t == N_NOT) {
     node_free(n->a);
     node_free(n->b);
@@ -433,23 +467,28 @@ static void node_free(node_t *n) {
 }
 
 static bool parser_err(parser_t *ps, const char *msg) {
-  if (!ps) return false;
-  snprintf(ps->err, sizeof(ps->err), "%s", msg ? msg : "expression parse error");
+  if (!ps)
+    return false;
+  snprintf(ps->err, sizeof(ps->err), "%s",
+           msg ? msg : "expression parse error");
   return false;
 }
 
 static bool ps_next(parser_t *ps) {
-  if (!ps) return false;
+  if (!ps)
+    return false;
   tok_free(&ps->cur);
   if (!lex_next(&ps->lx, &ps->cur)) {
-    snprintf(ps->err, sizeof(ps->err), "%s", ps->lx.err[0] ? ps->lx.err : "expression parse error");
+    snprintf(ps->err, sizeof(ps->err), "%s",
+             ps->lx.err[0] ? ps->lx.err : "expression parse error");
     return false;
   }
   return true;
 }
 
 static node_t *ps_new_node(parser_t *ps, enum node_type t) {
-  if (!ps) return NULL;
+  if (!ps)
+    return NULL;
   if (ps->node_count >= 2048) {
     parser_err(ps, "expression too complex");
     return NULL;
@@ -465,13 +504,16 @@ static node_t *ps_new_node(parser_t *ps, enum node_type t) {
 }
 
 static bool ps_expect(parser_t *ps, enum tok_type t, const char *msg) {
-  if (!ps) return false;
-  if (ps->cur.t != t) return parser_err(ps, msg);
+  if (!ps)
+    return false;
+  if (ps->cur.t != t)
+    return parser_err(ps, msg);
   return ps_next(ps);
 }
 
 static bool ps_parse_operand(parser_t *ps, operand_t *out) {
-  if (!ps || !out) return false;
+  if (!ps || !out)
+    return false;
   memset(out, 0, sizeof(*out));
 
   if (ps->cur.t == TOK_FIELD) {
@@ -501,37 +543,41 @@ static bool ps_parse_operand(parser_t *ps, operand_t *out) {
 }
 
 static bool tok_is_cmp(enum tok_type t) {
-  return (t == TOK_EQ || t == TOK_NE || t == TOK_LT || t == TOK_LE || t == TOK_GT || t == TOK_GE);
+  return (t == TOK_EQ || t == TOK_NE || t == TOK_LT || t == TOK_LE ||
+          t == TOK_GT || t == TOK_GE);
 }
 
 static enum cmp_op tok_to_cmp(enum tok_type t) {
   switch (t) {
-    case TOK_EQ:
-      return CMP_EQ;
-    case TOK_NE:
-      return CMP_NE;
-    case TOK_LT:
-      return CMP_LT;
-    case TOK_LE:
-      return CMP_LE;
-    case TOK_GT:
-      return CMP_GT;
-    case TOK_GE:
-      return CMP_GE;
-    default:
-      return CMP_EQ;
+  case TOK_EQ:
+    return CMP_EQ;
+  case TOK_NE:
+    return CMP_NE;
+  case TOK_LT:
+    return CMP_LT;
+  case TOK_LE:
+    return CMP_LE;
+  case TOK_GT:
+    return CMP_GT;
+  case TOK_GE:
+    return CMP_GE;
+  default:
+    return CMP_EQ;
   }
 }
 
 static node_t *ps_parse_expr(parser_t *ps);
 
 static node_t *ps_parse_primary(parser_t *ps) {
-  if (!ps) return NULL;
+  if (!ps)
+    return NULL;
 
   if (ps->cur.t == TOK_LPAREN) {
-    if (!ps_next(ps)) return NULL;
+    if (!ps_next(ps))
+      return NULL;
     node_t *inner = ps_parse_expr(ps);
-    if (!inner) return NULL;
+    if (!inner)
+      return NULL;
     if (!ps_expect(ps, TOK_RPAREN, "missing ')'")) {
       node_free(inner);
       return NULL;
@@ -542,7 +588,8 @@ static node_t *ps_parse_primary(parser_t *ps) {
   /* comparison */
   operand_t l;
   operand_t r;
-  if (!ps_parse_operand(ps, &l)) return NULL;
+  if (!ps_parse_operand(ps, &l))
+    return NULL;
   if (!tok_is_cmp(ps->cur.t)) {
     operand_free(&l);
     parser_err(ps, "missing comparison operator");
@@ -571,11 +618,14 @@ static node_t *ps_parse_primary(parser_t *ps) {
 }
 
 static node_t *ps_parse_unary(parser_t *ps) {
-  if (!ps) return NULL;
+  if (!ps)
+    return NULL;
   if (ps->cur.t == TOK_NOT) {
-    if (!ps_next(ps)) return NULL;
+    if (!ps_next(ps))
+      return NULL;
     node_t *inner = ps_parse_unary(ps);
-    if (!inner) return NULL;
+    if (!inner)
+      return NULL;
     node_t *n = ps_new_node(ps, N_NOT);
     if (!n) {
       node_free(inner);
@@ -588,9 +638,11 @@ static node_t *ps_parse_unary(parser_t *ps) {
 }
 
 static node_t *ps_parse_and(parser_t *ps) {
-  if (!ps) return NULL;
+  if (!ps)
+    return NULL;
   node_t *left = ps_parse_unary(ps);
-  if (!left) return NULL;
+  if (!left)
+    return NULL;
   while (ps->cur.t == TOK_AND) {
     if (!ps_next(ps)) {
       node_free(left);
@@ -615,9 +667,11 @@ static node_t *ps_parse_and(parser_t *ps) {
 }
 
 static node_t *ps_parse_or(parser_t *ps) {
-  if (!ps) return NULL;
+  if (!ps)
+    return NULL;
   node_t *left = ps_parse_and(ps);
-  if (!left) return NULL;
+  if (!left)
+    return NULL;
   while (ps->cur.t == TOK_OR) {
     if (!ps_next(ps)) {
       node_free(left);
@@ -644,15 +698,18 @@ static node_t *ps_parse_or(parser_t *ps) {
 static node_t *ps_parse_expr(parser_t *ps) { return ps_parse_or(ps); }
 
 static node_t *filter_parse_expr(const char *expr, char err[256]) {
-  if (err) err[0] = '\0';
+  if (err)
+    err[0] = '\0';
   if (!expr || !*expr) {
-    if (err) snprintf(err, 256, "empty expression");
+    if (err)
+      snprintf(err, 256, "empty expression");
     return NULL;
   }
 
   size_t elen = strlen(expr);
   if (elen > 4096) {
-    if (err) snprintf(err, 256, "expression too long");
+    if (err)
+      snprintf(err, 256, "expression too long");
     return NULL;
   }
 
@@ -667,21 +724,24 @@ static node_t *filter_parse_expr(const char *expr, char err[256]) {
 
   /* prime */
   if (!ps_next(&ps)) {
-    if (err) snprintf(err, 256, "%s", ps.err[0] ? ps.err : "expression parse error");
+    if (err)
+      snprintf(err, 256, "%s", ps.err[0] ? ps.err : "expression parse error");
     tok_free(&ps.cur);
     return NULL;
   }
 
   node_t *root = ps_parse_expr(&ps);
   if (!root) {
-    if (err) snprintf(err, 256, "%s", ps.err[0] ? ps.err : "expression parse error");
+    if (err)
+      snprintf(err, 256, "%s", ps.err[0] ? ps.err : "expression parse error");
     tok_free(&ps.cur);
     return NULL;
   }
 
   if (ps.cur.t != TOK_EOF) {
     node_free(root);
-    if (err) snprintf(err, 256, "unexpected token");
+    if (err)
+      snprintf(err, 256, "unexpected token");
     tok_free(&ps.cur);
     return NULL;
   }
@@ -700,50 +760,55 @@ typedef struct {
 static bool eval_operand_view(const operand_t *o, const uint8_t **p, size_t *n,
                               eval_ctx_t *ctx) {
   (void)ctx;
-  if (!o || !p || !n) return false;
+  if (!o || !p || !n)
+    return false;
   *p = (const uint8_t *)"";
   *n = 0;
   switch (o->t) {
-    case OP_FIELD: {
-      uint64_t idx = o->field_idx;
-      if (idx == 0) {
-        *p = (const uint8_t *)"";
-        *n = 0;
-        return true;
-      }
-      size_t z = (size_t)(idx - 1);
-      if (!ctx || z >= ctx->field_count) {
-        *p = (const uint8_t *)"";
-        *n = 0;
-        return true;
-      }
-      *p = ctx->fields[z].ptr;
-      *n = ctx->fields[z].len;
+  case OP_FIELD: {
+    uint64_t idx = o->field_idx;
+    if (idx == 0) {
+      *p = (const uint8_t *)"";
+      *n = 0;
       return true;
     }
-    case OP_INT:
-      *p = (const uint8_t *)o->s;
-      *n = o->slen;
+    size_t z = (size_t)(idx - 1);
+    if (!ctx || z >= ctx->field_count) {
+      *p = (const uint8_t *)"";
+      *n = 0;
       return true;
-    case OP_STR:
-      *p = (const uint8_t *)o->s;
-      *n = o->slen;
-      return true;
-    default:
-      return false;
+    }
+    *p = ctx->fields[z].ptr;
+    *n = ctx->fields[z].len;
+    return true;
+  }
+  case OP_INT:
+    *p = (const uint8_t *)o->s;
+    *n = o->slen;
+    return true;
+  case OP_STR:
+    *p = (const uint8_t *)o->s;
+    *n = o->slen;
+    return true;
+  default:
+    return false;
   }
 }
 
 static bool eval_cmp(const node_t *n, eval_ctx_t *ctx, bool *exec_limit) {
-  if (exec_limit) *exec_limit = false;
-  if (!n || !ctx || !exec_limit) return false;
+  if (exec_limit)
+    *exec_limit = false;
+  if (!n || !ctx || !exec_limit)
+    return false;
 
   const uint8_t *lp = NULL;
   size_t ln = 0;
   const uint8_t *rp = NULL;
   size_t rn = 0;
-  if (!eval_operand_view(&n->l, &lp, &ln, ctx)) return false;
-  if (!eval_operand_view(&n->r, &rp, &rn, ctx)) return false;
+  if (!eval_operand_view(&n->l, &lp, &ln, ctx))
+    return false;
+  if (!eval_operand_view(&n->r, &rp, &rn, ctx))
+    return false;
 
   int64_t li = 0;
   int64_t ri = 0;
@@ -752,43 +817,45 @@ static bool eval_cmp(const node_t *n, eval_ctx_t *ctx, bool *exec_limit) {
 
   if (lnum && rnum) {
     switch (n->cop) {
-      case CMP_EQ:
-        return li == ri;
-      case CMP_NE:
-        return li != ri;
-      case CMP_LT:
-        return li < ri;
-      case CMP_LE:
-        return li <= ri;
-      case CMP_GT:
-        return li > ri;
-      case CMP_GE:
-        return li >= ri;
+    case CMP_EQ:
+      return li == ri;
+    case CMP_NE:
+      return li != ri;
+    case CMP_LT:
+      return li < ri;
+    case CMP_LE:
+      return li <= ri;
+    case CMP_GT:
+      return li > ri;
+    case CMP_GE:
+      return li >= ri;
     }
     return false;
   }
 
   int c = bytes_cmp(lp, ln, rp, rn);
   switch (n->cop) {
-    case CMP_EQ:
-      return c == 0;
-    case CMP_NE:
-      return c != 0;
-    case CMP_LT:
-      return c < 0;
-    case CMP_LE:
-      return c <= 0;
-    case CMP_GT:
-      return c > 0;
-    case CMP_GE:
-      return c >= 0;
+  case CMP_EQ:
+    return c == 0;
+  case CMP_NE:
+    return c != 0;
+  case CMP_LT:
+    return c < 0;
+  case CMP_LE:
+    return c <= 0;
+  case CMP_GT:
+    return c > 0;
+  case CMP_GE:
+    return c >= 0;
   }
   return false;
 }
 
 static bool eval_bool(const node_t *n, eval_ctx_t *ctx, bool *exec_limit) {
-  if (exec_limit) *exec_limit = false;
-  if (!n || !ctx || !exec_limit) return false;
+  if (exec_limit)
+    *exec_limit = false;
+  if (!n || !ctx || !exec_limit)
+    return false;
 
   ctx->steps++;
   if (ctx->steps > ctx->step_limit) {
@@ -797,49 +864,51 @@ static bool eval_bool(const node_t *n, eval_ctx_t *ctx, bool *exec_limit) {
   }
 
   switch (n->t) {
-    case N_CMP:
-      return eval_cmp(n, ctx, exec_limit);
-    case N_NOT: {
-      bool lim = false;
-      bool v = eval_bool(n->a, ctx, &lim);
-      if (lim) {
-        *exec_limit = true;
-        return false;
-      }
-      return !v;
-    }
-    case N_AND: {
-      bool lim = false;
-      bool lv = eval_bool(n->a, ctx, &lim);
-      if (lim) {
-        *exec_limit = true;
-        return false;
-      }
-      if (!lv) return false;
-      bool rv = eval_bool(n->b, ctx, &lim);
-      if (lim) {
-        *exec_limit = true;
-        return false;
-      }
-      return rv;
-    }
-    case N_OR: {
-      bool lim = false;
-      bool lv = eval_bool(n->a, ctx, &lim);
-      if (lim) {
-        *exec_limit = true;
-        return false;
-      }
-      if (lv) return true;
-      bool rv = eval_bool(n->b, ctx, &lim);
-      if (lim) {
-        *exec_limit = true;
-        return false;
-      }
-      return rv;
-    }
-    default:
+  case N_CMP:
+    return eval_cmp(n, ctx, exec_limit);
+  case N_NOT: {
+    bool lim = false;
+    bool v = eval_bool(n->a, ctx, &lim);
+    if (lim) {
+      *exec_limit = true;
       return false;
+    }
+    return !v;
+  }
+  case N_AND: {
+    bool lim = false;
+    bool lv = eval_bool(n->a, ctx, &lim);
+    if (lim) {
+      *exec_limit = true;
+      return false;
+    }
+    if (!lv)
+      return false;
+    bool rv = eval_bool(n->b, ctx, &lim);
+    if (lim) {
+      *exec_limit = true;
+      return false;
+    }
+    return rv;
+  }
+  case N_OR: {
+    bool lim = false;
+    bool lv = eval_bool(n->a, ctx, &lim);
+    if (lim) {
+      *exec_limit = true;
+      return false;
+    }
+    if (lv)
+      return true;
+    bool rv = eval_bool(n->b, ctx, &lim);
+    if (lim) {
+      *exec_limit = true;
+      return false;
+    }
+    return rv;
+  }
+  default:
+    return false;
   }
 }
 
@@ -848,12 +917,15 @@ static bool eval_bool(const node_t *n, eval_ctx_t *ctx, bool *exec_limit) {
  * =============================================================================
  */
 
-static int filter_main(const char *expr, char *const *files, size_t file_count) {
+static int filter_main(const char *expr, char *const *files,
+                       size_t file_count) {
   char perr[256];
   node_t *ast = filter_parse_expr(expr, perr);
   if (!ast) {
-    if (perr[0]) fprintf(stderr, "filter: %s\n", perr);
-    else fprintf(stderr, "filter: expression parse error\n");
+    if (perr[0])
+      fprintf(stderr, "filter: %s\n", perr);
+    else
+      fprintf(stderr, "filter: expression parse error\n");
     return 2;
   }
 
@@ -881,7 +953,8 @@ static int filter_main(const char *expr, char *const *files, size_t file_count) 
 
     /* Exclude trailing '\n' from field content */
     size_t subj_len = v.len;
-    if (v.ends_with_nl && subj_len > 0) subj_len--;
+    if (v.ends_with_nl && subj_len > 0)
+      subj_len--;
 
     dc_field_view_t *fields = NULL;
     size_t fcnt = dc_split_delim(v.ptr, subj_len, delim, &fields);
@@ -943,8 +1016,7 @@ Parsing rules (Diamond style):
 - Any other -x token is an error unless after --, or token is exactly '-'.
 - EXPR is required and is the first non-option token.
 */
-__attribute__((visibility("default")))
-int filter_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int filter_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
@@ -963,7 +1035,8 @@ int filter_builtin(WORD_LIST *list) {
   int rc = 2;
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!expr) {
       if (!end_opts && strcmp(tok, "--help") == 0) {
@@ -974,7 +1047,8 @@ int filter_builtin(WORD_LIST *list) {
         end_opts = true;
         continue;
       }
-      if (!end_opts && tok[0] == '-' && tok[1] != '\0' && strcmp(tok, "-") != 0) {
+      if (!end_opts && tok[0] == '-' && tok[1] != '\0' &&
+          strcmp(tok, "-") != 0) {
         rc = filter_usage_err("unknown option (use --help)");
         goto out;
       }
@@ -1017,12 +1091,11 @@ out:
   return rc;
 }
 
-__attribute__((visibility("default")))
-struct builtin filter_struct = {
-  .name = "filter",
-  .function = filter_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = filter_doc,
-  .short_doc = (char *)"filter EXPR [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin filter_struct = {
+    .name = "filter",
+    .function = filter_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = filter_doc,
+    .short_doc = (char *)"filter EXPR [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_lines.c
+++ b/src/builtins/builtin_lines.c
@@ -3,34 +3,38 @@
 #include "diamondcore.h"
 
 #include <errno.h>
+#include <signal.h> // ANCHOR:SIGPIPE-INCLUDE
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>  // ANCHOR:SIGPIPE-INCLUDE
 
 // Bash loadable builtin headers (vendored minimal subset for loadables)
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *lines_shortdoc = "lines SPEC [--] [FILE...]";
+__attribute__((unused)) static const char *lines_shortdoc =
+    "lines SPEC [--] [FILE...]";
 
 static char *lines_doc[] = {
-  "Select and emit specific 1-based input lines by numeric index or range.",
-  (char *)0,
+    "Select and emit specific 1-based input lines by numeric index or range.",
+    (char *)0,
 };
 
 static int lines_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "lines: %s\n", msg);
-  else dc_print_usage_lines(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "lines: %s\n", msg);
+  else
+    dc_print_usage_lines(stderr);
   return 2;
 }
 
 static int lines_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "lines: %s\n", msg);
-  else fprintf(stderr, "lines: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "lines: %s\n", msg);
+  else
+    fprintf(stderr, "lines: I/O error\n");
   return 2;
 }
 
@@ -106,10 +110,10 @@ static int lines_main(const char *spec, char *const *files, size_t file_count) {
 // - Only --help is recognized.
 // - Any other -x token is an error unless after --, or token is exactly '-'.
 // - SPEC is required and is the first non-option token.
-__attribute__((visibility("default")))
-int lines_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int lines_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
-  // Ignore SIGPIPE so closed-pipe writes surface as stdio errors (EPIPE) and we return 2.
+  // Ignore SIGPIPE so closed-pipe writes surface as stdio errors (EPIPE) and we
+  // return 2.
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
 
@@ -129,7 +133,8 @@ int lines_builtin(WORD_LIST *list) {
   // === ANCHOR:ARGV-PARSE-BEGIN ===
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!spec) {
       if (!end_opts && strcmp(tok, "--help") == 0) {
@@ -141,7 +146,8 @@ int lines_builtin(WORD_LIST *list) {
         continue;
       }
 
-      if (!end_opts && tok[0] == '-' && tok[1] != '\0' && strcmp(tok, "-") != 0) {
+      if (!end_opts && tok[0] == '-' && tok[1] != '\0' &&
+          strcmp(tok, "-") != 0) {
         rc = lines_usage_err("unknown option (use --help)");
         goto out;
       }
@@ -188,12 +194,11 @@ out:
   // === ANCHOR:CLEANUP-END ===
 }
 
-__attribute__((visibility("default")))
-struct builtin lines_struct = {
-  .name = "lines",
-  .function = lines_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = lines_doc,
-  .short_doc = (char *)"lines SPEC [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin lines_struct = {
+    .name = "lines",
+    .function = lines_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = lines_doc,
+    .short_doc = (char *)"lines SPEC [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_match.c
+++ b/src/builtins/builtin_match.c
@@ -1,35 +1,39 @@
 // builtin_match.c - `match` loadable builtin
 
-#include "diamondcore.h"
 #include "dc_regex.h"
+#include "diamondcore.h"
 
+#include <signal.h> // ANCHOR:SIGPIPE-INCLUDE
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>  // ANCHOR:SIGPIPE-INCLUDE
 
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *match_shortdoc = "match PATTERN [--] [FILE...]";
+__attribute__((unused)) static const char *match_shortdoc =
+    "match PATTERN [--] [FILE...]";
 
 static char *match_doc[] = {
-  "Filter input lines by a deterministic, constrained regex.",
-  (char *)0,
+    "Filter input lines by a deterministic, constrained regex.",
+    (char *)0,
 };
 
 static int match_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "match: %s\n", msg);
-  else dc_print_usage_match(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "match: %s\n", msg);
+  else
+    dc_print_usage_match(stderr);
   return 2;
 }
 
 static int match_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "match: %s\n", msg);
-  else fprintf(stderr, "match: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "match: %s\n", msg);
+  else
+    fprintf(stderr, "match: I/O error\n");
   return 2;
 }
 
@@ -38,13 +42,16 @@ static int match_help(void) {
   return 0;
 }
 
-static int match_main(const char *pattern, char *const *files, size_t file_count) {
+static int match_main(const char *pattern, char *const *files,
+                      size_t file_count) {
   char errbuf[256];
   dc_regex_t *re = NULL;
 
   if (!dc_regex_compile(&re, pattern, errbuf)) {
-    if (errbuf[0]) fprintf(stderr, "%s\n", errbuf);
-    else fprintf(stderr, "match: pattern compile error\n");
+    if (errbuf[0])
+      fprintf(stderr, "%s\n", errbuf);
+    else
+      fprintf(stderr, "match: pattern compile error\n");
     return 2;
   }
 
@@ -72,7 +79,8 @@ static int match_main(const char *pattern, char *const *files, size_t file_count
     // Match against the line content excluding a terminating '\n' (if present),
     // but always emit the original bytes verbatim when matched.
     size_t subj_len = v.len;
-    if (v.ends_with_nl && subj_len > 0) subj_len--;
+    if (v.ends_with_nl && subj_len > 0)
+      subj_len--;
 
     bool exec_limit = false;
     bool matched = dc_regex_match_line(re, v.ptr, subj_len, &exec_limit);
@@ -92,7 +100,8 @@ static int match_main(const char *pattern, char *const *files, size_t file_count
           return match_io_err("write error");
         }
 
-        // Force the kernel write while SIGPIPE is ignored, and verify stdio state.
+        // Force the kernel write while SIGPIPE is ignored, and verify stdio
+        // state.
         if (fflush(stdout) != 0 || ferror(stdout)) {
           dc_lr_close(lr);
           dc_regex_free(re);
@@ -121,8 +130,7 @@ Parsing rules (same style as lines):
 - Any other -x token is an error unless after --, or token is exactly '-'.
 - PATTERN is required and is the first non-option token.
 */
-__attribute__((visibility("default")))
-int match_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int match_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
@@ -142,13 +150,21 @@ int match_builtin(WORD_LIST *list) {
 
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!pattern) {
-      if (!end_opts && strcmp(tok, "--help") == 0) { rc = match_help(); goto out; }
-      if (!end_opts && strcmp(tok, "--") == 0) { end_opts = true; continue; }
+      if (!end_opts && strcmp(tok, "--help") == 0) {
+        rc = match_help();
+        goto out;
+      }
+      if (!end_opts && strcmp(tok, "--") == 0) {
+        end_opts = true;
+        continue;
+      }
 
-      if (!end_opts && tok[0] == '-' && tok[1] != '\0' && strcmp(tok, "-") != 0) {
+      if (!end_opts && tok[0] == '-' && tok[1] != '\0' &&
+          strcmp(tok, "-") != 0) {
         rc = match_usage_err("unknown option (use --help)");
         goto out;
       }
@@ -157,7 +173,10 @@ int match_builtin(WORD_LIST *list) {
       continue;
     }
 
-    if (!end_opts && strcmp(tok, "--") == 0) { end_opts = true; continue; }
+    if (!end_opts && strcmp(tok, "--") == 0) {
+      end_opts = true;
+      continue;
+    }
 
     if (!end_opts && tok[0] == '-' && tok[1] != '\0' && strcmp(tok, "-") != 0) {
       rc = match_usage_err("unknown option (use --help)");
@@ -167,14 +186,20 @@ int match_builtin(WORD_LIST *list) {
     if (fcnt == fcap) {
       size_t ncap = fcap * 2;
       char **nf = (char **)realloc(files, ncap * sizeof(char *));
-      if (!nf) { rc = match_io_err("out of memory"); goto out; }
+      if (!nf) {
+        rc = match_io_err("out of memory");
+        goto out;
+      }
       files = nf;
       fcap = ncap;
     }
     files[fcnt++] = (char *)tok;
   }
 
-  if (!pattern) { rc = match_usage_err("missing PATTERN"); goto out; }
+  if (!pattern) {
+    rc = match_usage_err("missing PATTERN");
+    goto out;
+  }
 
   rc = match_main(pattern, files, fcnt);
 
@@ -184,12 +209,11 @@ out:
   return rc;
 }
 
-__attribute__((visibility("default")))
-struct builtin match_struct = {
-  .name = "match",
-  .function = match_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = match_doc,
-  .short_doc = (char *)"match PATTERN [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin match_struct = {
+    .name = "match",
+    .function = match_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = match_doc,
+    .short_doc = (char *)"match PATTERN [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_replace.c
+++ b/src/builtins/builtin_replace.c
@@ -1,82 +1,89 @@
-#include "diamondcore.h"
 #include "dc_regex.h"
+#include "diamondcore.h"
 
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>
 
 #include "builtins.h"
 #include "shell.h"
 
 static char *replace_doc[] = {
-  "Perform per-line substitution and emit only modified lines.",
-  (char *)0,
+    "Perform per-line substitution and emit only modified lines.",
+    (char *)0,
 };
 
 static int usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "replace: %s\n", msg);
+  if (msg && *msg)
+    fprintf(stderr, "replace: %s\n", msg);
   dc_print_usage_replace(stderr);
   return 2;
 }
 
 static bool write_bytes(const uint8_t *p, size_t n) {
-  if (n == 0) return true;
+  if (n == 0)
+    return true;
   size_t w = fwrite(p, 1, n, stdout);
   return (w == n) && !ferror(stdout);
 }
 
 static bool bytes_eq(const uint8_t *a, const uint8_t *b, size_t n) {
-  if (n == 0) return true;
+  if (n == 0)
+    return true;
   return memcmp(a, b, n) == 0;
 }
 
-static bool literal_find_next(const uint8_t *hay,
-                              size_t hay_len,
-                              const uint8_t *needle,
-                              size_t needle_len,
-                              size_t start_at,
-                              size_t *out_start,
+static bool literal_find_next(const uint8_t *hay, size_t hay_len,
+                              const uint8_t *needle, size_t needle_len,
+                              size_t start_at, size_t *out_start,
                               size_t *out_end) {
-  if (!hay || !needle) return false;
-  if (needle_len == 0) return false;
-  if (start_at > hay_len) return false;
-  if (needle_len > hay_len) return false;
+  if (!hay || !needle)
+    return false;
+  if (needle_len == 0)
+    return false;
+  if (start_at > hay_len)
+    return false;
+  if (needle_len > hay_len)
+    return false;
 
   size_t last = hay_len - needle_len;
   for (size_t i = start_at; i <= last; i++) {
     if (bytes_eq(hay + i, needle, needle_len)) {
-      if (out_start) *out_start = i;
-      if (out_end) *out_end = i + needle_len;
+      if (out_start)
+        *out_start = i;
+      if (out_end)
+        *out_end = i + needle_len;
       return true;
     }
   }
   return false;
 }
 
-static int process_record_literal(const uint8_t *content,
-                                 size_t content_len,
-                                 const uint8_t *pat,
-                                 size_t pat_len,
-                                 const uint8_t *rep,
-                                 size_t rep_len,
-                                 bool has_delim) {
+static int process_record_literal(const uint8_t *content, size_t content_len,
+                                  const uint8_t *pat, size_t pat_len,
+                                  const uint8_t *rep, size_t rep_len,
+                                  bool has_delim) {
   size_t s = 0, e = 0;
-  if (!literal_find_next(content, content_len, pat, pat_len, 0, &s, &e)) return 1;
+  if (!literal_find_next(content, content_len, pat, pat_len, 0, &s, &e))
+    return 1;
 
   size_t last = 0;
   size_t cursor = 0;
 
   for (;;) {
-    if (!literal_find_next(content, content_len, pat, pat_len, cursor, &s, &e)) break;
+    if (!literal_find_next(content, content_len, pat, pat_len, cursor, &s, &e))
+      break;
 
     if (s > last) {
-      if (!write_bytes(content + last, s - last)) return 2;
+      if (!write_bytes(content + last, s - last))
+        return 2;
     }
     if (rep_len > 0) {
-      if (!write_bytes(rep, rep_len)) return 2;
+      if (!write_bytes(rep, rep_len))
+        return 2;
     }
 
     last = e;
@@ -84,28 +91,28 @@ static int process_record_literal(const uint8_t *content,
   }
 
   if (last < content_len) {
-    if (!write_bytes(content + last, content_len - last)) return 2;
+    if (!write_bytes(content + last, content_len - last))
+      return 2;
   }
 
   if (has_delim) {
     uint8_t nl = 0x0A;
-    if (!write_bytes(&nl, 1)) return 2;
+    if (!write_bytes(&nl, 1))
+      return 2;
   }
 
   return 0;
 }
 
-static int process_record_regex(const uint8_t *content,
-                               size_t content_len,
-                               const dc_regex_t *re,
-                               const uint8_t *rep,
-                               size_t rep_len,
-                               bool has_delim) {
+static int process_record_regex(const uint8_t *content, size_t content_len,
+                                const dc_regex_t *re, const uint8_t *rep,
+                                size_t rep_len, bool has_delim) {
   size_t s = 0, e = 0;
   bool limit = false;
 
   if (!dc_regex_find_next(re, content, content_len, 0, &s, &e, &limit)) {
-    if (limit) return 3;
+    if (limit)
+      return 3;
     return 1;
   }
 
@@ -115,33 +122,41 @@ static int process_record_regex(const uint8_t *content,
   for (;;) {
     limit = false;
     if (!dc_regex_find_next(re, content, content_len, cursor, &s, &e, &limit)) {
-      if (limit) return 3;
+      if (limit)
+        return 3;
       break;
     }
 
     if (s > last) {
-      if (!write_bytes(content + last, s - last)) return 2;
+      if (!write_bytes(content + last, s - last))
+        return 2;
     }
     if (rep_len > 0) {
-      if (!write_bytes(rep, rep_len)) return 2;
+      if (!write_bytes(rep, rep_len))
+        return 2;
     }
 
     last = e;
 
     /* Zero-length match must advance by >= 1 byte */
-    if (e > cursor) cursor = e;
-    else cursor = (cursor < content_len) ? (cursor + 1) : (content_len + 1);
+    if (e > cursor)
+      cursor = e;
+    else
+      cursor = (cursor < content_len) ? (cursor + 1) : (content_len + 1);
 
-    if (cursor > content_len) break;
+    if (cursor > content_len)
+      break;
   }
 
   if (last < content_len) {
-    if (!write_bytes(content + last, content_len - last)) return 2;
+    if (!write_bytes(content + last, content_len - last))
+      return 2;
   }
 
   if (has_delim) {
     uint8_t nl = 0x0A;
-    if (!write_bytes(&nl, 1)) return 2;
+    if (!write_bytes(&nl, 1))
+      return 2;
   }
 
   return 0;
@@ -168,7 +183,8 @@ static int replace_builtin(WORD_LIST *list) {
 
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *arg = w->word->word;
-    if (!arg) continue;
+    if (!arg)
+      continue;
 
     /* --help only recognized during option parsing, before PATTERN */
     if (!end_opts && pattern_s == NULL && strcmp(arg, "--help") == 0) {
@@ -199,9 +215,10 @@ static int replace_builtin(WORD_LIST *list) {
       continue;
     }
 
-    /* Strict option parsing: any '-' token before '--' and before PATTERN is an option token.
-     * Since replace has positional-primary PATTERN, unknown option tokens are usage errors.
-     * This intentionally includes single "-" (pattern beginning with '-' requires '--').
+    /* Strict option parsing: any '-' token before '--' and before PATTERN is an
+     * option token. Since replace has positional-primary PATTERN, unknown
+     * option tokens are usage errors. This intentionally includes single "-"
+     * (pattern beginning with '-' requires '--').
      */
     if (!end_opts && pattern_s == NULL && arg[0] == '-') {
       free(files);
@@ -256,8 +273,10 @@ static int replace_builtin(WORD_LIST *list) {
     errbuf[0] = '\0';
     if (!dc_regex_compile(&re, pattern_s, errbuf)) {
       if (errbuf[0]) {
-        if (strncmp(errbuf, "match:", 6) == 0) fprintf(stderr, "replace:%s\n", errbuf + 6);
-        else fprintf(stderr, "replace: %s\n", errbuf);
+        if (strncmp(errbuf, "match:", 6) == 0)
+          fprintf(stderr, "replace:%s\n", errbuf + 6);
+        else
+          fprintf(stderr, "replace: %s\n", errbuf);
       } else {
         fprintf(stderr, "replace: regex compile error\n");
       }
@@ -272,10 +291,12 @@ static int replace_builtin(WORD_LIST *list) {
 
   dc_line_reader_t *lr = dc_lr_open(files, file_count, &err);
   if (!lr) {
-    if (re) dc_regex_free(re);
+    if (re)
+      dc_regex_free(re);
     free(files);
     signal(SIGPIPE, old_sigpipe);
-    fprintf(stderr, "replace: %s\n", err.msg[0] ? err.msg : "cannot open input");
+    fprintf(stderr, "replace: %s\n",
+            err.msg[0] ? err.msg : "cannot open input");
     return 2;
   }
 
@@ -288,7 +309,8 @@ static int replace_builtin(WORD_LIST *list) {
     if (!ok) {
       if (err.code != DC_ERR_NONE) {
         dc_lr_close(lr);
-        if (re) dc_regex_free(re);
+        if (re)
+          dc_regex_free(re);
         free(files);
         signal(SIGPIPE, old_sigpipe);
         fprintf(stderr, "replace: %s\n", err.msg[0] ? err.msg : "read error");
@@ -298,13 +320,16 @@ static int replace_builtin(WORD_LIST *list) {
     }
 
     size_t content_len = v.len;
-    if (v.ends_with_nl && content_len > 0) content_len--;
+    if (v.ends_with_nl && content_len > 0)
+      content_len--;
 
     int rc;
     if (literal) {
-      rc = process_record_literal(v.ptr, content_len, pat, pat_len, rep, rep_len, v.ends_with_nl);
+      rc = process_record_literal(v.ptr, content_len, pat, pat_len, rep,
+                                  rep_len, v.ends_with_nl);
     } else {
-      rc = process_record_regex(v.ptr, content_len, re, rep, rep_len, v.ends_with_nl);
+      rc = process_record_regex(v.ptr, content_len, re, rep, rep_len,
+                                v.ends_with_nl);
       if (rc == 3) {
         fprintf(stderr, "replace: regex execution limit exceeded\n");
         dc_lr_close(lr);
@@ -319,7 +344,8 @@ static int replace_builtin(WORD_LIST *list) {
       emitted_any = true;
     } else if (rc == 2) {
       dc_lr_close(lr);
-      if (re) dc_regex_free(re);
+      if (re)
+        dc_regex_free(re);
       free(files);
       signal(SIGPIPE, old_sigpipe);
       return 2;
@@ -327,7 +353,8 @@ static int replace_builtin(WORD_LIST *list) {
   }
 
   dc_lr_close(lr);
-  if (re) dc_regex_free(re);
+  if (re)
+    dc_regex_free(re);
   free(files);
 
   if (emitted_any) {
@@ -341,12 +368,12 @@ static int replace_builtin(WORD_LIST *list) {
   return emitted_any ? 0 : 1;
 }
 
-__attribute__((visibility("default")))
-struct builtin replace_struct = {
-  .name = "replace",
-  .function = replace_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = replace_doc,
-  .short_doc = (char *)"replace [--literal] PATTERN REPLACEMENT [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin replace_struct = {
+    .name = "replace",
+    .function = replace_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = replace_doc,
+    .short_doc =
+        (char *)"replace [--literal] PATTERN REPLACEMENT [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_table.c
+++ b/src/builtins/builtin_table.c
@@ -15,8 +15,8 @@
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *table_shortdoc = "table [--] [FILE...]";
+__attribute__((unused)) static const char *table_shortdoc =
+    "table [--] [FILE...]";
 
 static char *table_doc[] = {
     "Format delimited text into aligned columns for human output.",
@@ -25,14 +25,18 @@ static char *table_doc[] = {
 
 // === ANCHOR:ERROR-HELPERS-BEGIN ===
 static int table_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "table: %s\n", msg);
-  else dc_print_usage_table(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "table: %s\n", msg);
+  else
+    dc_print_usage_table(stderr);
   return 2;
 }
 
 static int table_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "table: %s\n", msg);
-  else fprintf(stderr, "table: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "table: %s\n", msg);
+  else
+    fprintf(stderr, "table: I/O error\n");
   return 2;
 }
 
@@ -49,9 +53,11 @@ static inline bool is_st_ws(uint8_t c) { return (c == ' ' || c == '\t'); }
 // - Returns number of fields; caller free()s *out_fields.
 // - On allocation failure returns (size_t)-1.
 static size_t table_split_space_tab(const uint8_t *line, size_t len,
-                                   dc_field_view_t **out_fields) {
-  if (out_fields) *out_fields = NULL;
-  if (!out_fields || (!line && len != 0)) return 0;
+                                    dc_field_view_t **out_fields) {
+  if (out_fields)
+    *out_fields = NULL;
+  if (!out_fields || (!line && len != 0))
+    return 0;
 
   dc_field_view_t *v = NULL;
   size_t cap = 0;
@@ -59,13 +65,17 @@ static size_t table_split_space_tab(const uint8_t *line, size_t len,
 
   size_t i = 0;
   while (i < len) {
-    while (i < len && is_st_ws(line[i])) i++;
-    if (i >= len) break;
+    while (i < len && is_st_ws(line[i]))
+      i++;
+    if (i >= len)
+      break;
 
     size_t start = i;
-    while (i < len && !is_st_ws(line[i])) i++;
+    while (i < len && !is_st_ws(line[i]))
+      i++;
     size_t flen = i - start;
-    if (flen == 0) continue;
+    if (flen == 0)
+      continue;
 
     if (cnt == cap) {
       size_t ncap = cap ? cap * 2 : 8;
@@ -108,16 +118,20 @@ static int table_nonseekable_err(void) {
 }
 
 static bool table_check_seekable_files(char *const *files, size_t file_count,
-                                      char *errbuf, size_t errcap) {
-  if (errbuf && errcap) errbuf[0] = '\0';
+                                       char *errbuf, size_t errcap) {
+  if (errbuf && errcap)
+    errbuf[0] = '\0';
 
-  if (file_count == 0) return false;
+  if (file_count == 0)
+    return false;
 
   for (size_t i = 0; i < file_count; i++) {
     const char *name = files[i];
-    if (!name) name = "";
+    if (!name)
+      name = "";
 
-    if (strcmp(name, "-") == 0) return false;
+    if (strcmp(name, "-") == 0)
+      return false;
 
     struct stat st;
     if (stat(name, &st) != 0) {
@@ -127,22 +141,27 @@ static bool table_check_seekable_files(char *const *files, size_t file_count,
       return false;
     }
 
-    if (!S_ISREG(st.st_mode)) return false;
+    if (!S_ISREG(st.st_mode))
+      return false;
   }
 
   return true;
 }
 
 static int table_pass_compute_widths(char *const *files, size_t file_count,
-                                    size_t **out_widths, size_t *out_ncols,
-                                    bool *out_any) {
-  if (out_widths) *out_widths = NULL;
-  if (out_ncols) *out_ncols = 0;
-  if (out_any) *out_any = false;
+                                     size_t **out_widths, size_t *out_ncols,
+                                     bool *out_any) {
+  if (out_widths)
+    *out_widths = NULL;
+  if (out_ncols)
+    *out_ncols = 0;
+  if (out_any)
+    *out_any = false;
 
   dc_error_t err;
   dc_line_reader_t *lr = dc_lr_open(files, file_count, &err);
-  if (!lr) return table_io_err(err.msg[0] ? err.msg : "cannot open input");
+  if (!lr)
+    return table_io_err(err.msg[0] ? err.msg : "cannot open input");
 
   size_t *widths = NULL;
   size_t ncols = 0;
@@ -162,7 +181,8 @@ static int table_pass_compute_widths(char *const *files, size_t file_count,
 
     const uint8_t *line = v.ptr;
     size_t linelen = v.len;
-    if (v.ends_with_nl && linelen > 0) linelen--; // exclude '\n'
+    if (v.ends_with_nl && linelen > 0)
+      linelen--; // exclude '\n'
 
     dc_field_view_t *fields = NULL;
     size_t nf = table_split_space_tab(line, linelen, &fields);
@@ -186,13 +206,15 @@ static int table_pass_compute_widths(char *const *files, size_t file_count,
         free(widths);
         return table_io_err("out of memory");
       }
-      for (size_t i = ncols; i < nf; i++) nw[i] = 0;
+      for (size_t i = ncols; i < nf; i++)
+        nw[i] = 0;
       widths = nw;
       ncols = nf;
     }
 
     for (size_t i = 0; i < nf; i++) {
-      if (fields[i].len > widths[i]) widths[i] = fields[i].len;
+      if (fields[i].len > widths[i])
+        widths[i] = fields[i].len;
     }
 
     free(fields);
@@ -200,23 +222,28 @@ static int table_pass_compute_widths(char *const *files, size_t file_count,
 
   dc_lr_close(lr);
 
-  if (out_widths) *out_widths = widths;
-  else free(widths);
+  if (out_widths)
+    *out_widths = widths;
+  else
+    free(widths);
 
-  if (out_ncols) *out_ncols = ncols;
-  if (out_any) *out_any = any;
+  if (out_ncols)
+    *out_ncols = ncols;
+  if (out_any)
+    *out_any = any;
 
   return 0;
 }
 
 static int table_pass_emit(char *const *files, size_t file_count,
-                           const size_t *widths, size_t ncols,
-                           bool *out_any) {
-  if (out_any) *out_any = false;
+                           const size_t *widths, size_t ncols, bool *out_any) {
+  if (out_any)
+    *out_any = false;
 
   dc_error_t err;
   dc_line_reader_t *lr = dc_lr_open(files, file_count, &err);
-  if (!lr) return table_io_err(err.msg[0] ? err.msg : "cannot open input");
+  if (!lr)
+    return table_io_err(err.msg[0] ? err.msg : "cannot open input");
 
   bool any = false;
 
@@ -233,7 +260,8 @@ static int table_pass_emit(char *const *files, size_t file_count,
 
     const uint8_t *line = v.ptr;
     size_t linelen = v.len;
-    if (v.ends_with_nl && linelen > 0) linelen--; // exclude '\n'
+    if (v.ends_with_nl && linelen > 0)
+      linelen--; // exclude '\n'
 
     dc_field_view_t *fields = NULL;
     size_t nf = table_split_space_tab(line, linelen, &fields);
@@ -265,7 +293,8 @@ static int table_pass_emit(char *const *files, size_t file_count,
         size_t colw = (i < ncols) ? widths[i] : 0;
         size_t minsep = table_min_sep(i);
         size_t pad = minsep;
-        if (colw > n) pad += (colw - n);
+        if (colw > n)
+          pad += (colw - n);
         for (size_t s = 0; s < pad; s++) {
           if (fputc(' ', stdout) == EOF) {
             free(fields);
@@ -295,7 +324,8 @@ static int table_pass_emit(char *const *files, size_t file_count,
     }
   }
 
-  if (out_any) *out_any = any;
+  if (out_any)
+    *out_any = any;
   return 0;
 }
 
@@ -303,7 +333,8 @@ static int table_pass_emit(char *const *files, size_t file_count,
 static int table_main(char *const *files, size_t file_count) {
   char errbuf[256];
   if (!table_check_seekable_files(files, file_count, errbuf, sizeof(errbuf))) {
-    if (errbuf[0]) return table_io_err(errbuf);
+    if (errbuf[0])
+      return table_io_err(errbuf);
     return table_nonseekable_err();
   }
 
@@ -325,7 +356,8 @@ static int table_main(char *const *files, size_t file_count) {
   bool any2 = false;
   rc = table_pass_emit(files, file_count, widths, ncols, &any2);
   free(widths);
-  if (rc != 0) return rc;
+  if (rc != 0)
+    return rc;
   return any2 ? 0 : 1;
 }
 // === ANCHOR:CORE-MAIN-END ===
@@ -333,8 +365,7 @@ static int table_main(char *const *files, size_t file_count) {
 // Parse rules:
 // - Recognizes --help and -- (end option parsing).
 // - Any other -x token before -- is an error unless token is exactly '-'.
-__attribute__((visibility("default")))
-int table_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int table_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
@@ -353,7 +384,8 @@ int table_builtin(WORD_LIST *list) {
 
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!end_opts && strcmp(tok, "--help") == 0) {
       rc = table_help();
@@ -392,8 +424,7 @@ out:
   return rc;
 }
 
-__attribute__((visibility("default")))
-struct builtin table_struct = {
+__attribute__((visibility("default"))) struct builtin table_struct = {
     .name = "table",
     .function = table_builtin,
     .flags = BUILTIN_ENABLED,

--- a/src/builtins/builtin_take.c
+++ b/src/builtins/builtin_take.c
@@ -3,34 +3,38 @@
 #include "diamondcore.h"
 
 #include <errno.h>
+#include <signal.h> // ANCHOR:SIGPIPE-INCLUDE
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>  // ANCHOR:SIGPIPE-INCLUDE
 
 // Bash loadable builtin headers (vendored minimal subset for loadables)
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *take_shortdoc = "take N [S] [--] [FILE...]";
+__attribute__((unused)) static const char *take_shortdoc =
+    "take N [S] [--] [FILE...]";
 
 static char *take_doc[] = {
-  "Emit a forward-only slice of input lines (take N [S]).",
-  (char *)0,
+    "Emit a forward-only slice of input lines (take N [S]).",
+    (char *)0,
 };
 
 static int take_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "take: %s\n", msg);
-  else dc_print_usage_take(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "take: %s\n", msg);
+  else
+    dc_print_usage_take(stderr);
   return 2;
 }
 
 static int take_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "take: %s\n", msg);
-  else fprintf(stderr, "take: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "take: %s\n", msg);
+  else
+    fprintf(stderr, "take: I/O error\n");
   return 2;
 }
 
@@ -39,7 +43,8 @@ static int take_help(void) {
   return 0;
 }
 
-static int take_main(uint64_t n, uint64_t s, char *const *files, size_t file_count) {
+static int take_main(uint64_t n, uint64_t s, char *const *files,
+                     size_t file_count) {
   dc_error_t err;
 
   dc_line_reader_t *lr = dc_lr_open(files, file_count, &err);
@@ -63,8 +68,10 @@ static int take_main(uint64_t n, uint64_t s, char *const *files, size_t file_cou
 
     line_no++;
 
-    if (line_no <= s) continue;
-    if (emitted >= n) break;
+    if (line_no <= s)
+      continue;
+    if (emitted >= n)
+      break;
 
     if (n > 0) {
       if (v.len > 0) {
@@ -75,7 +82,8 @@ static int take_main(uint64_t n, uint64_t s, char *const *files, size_t file_cou
         }
       }
       emitted++;
-      if (emitted >= n) break;
+      if (emitted >= n)
+        break;
     }
   }
 
@@ -96,10 +104,10 @@ static int take_main(uint64_t n, uint64_t s, char *const *files, size_t file_cou
 // - N is required (first positional).
 // - S is optional (second positional).
 // - Remaining tokens are FILE...
-__attribute__((visibility("default")))
-int take_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int take_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
-  // Ignore SIGPIPE so closed-pipe writes surface as stdio errors (EPIPE) and we return 2.
+  // Ignore SIGPIPE so closed-pipe writes surface as stdio errors (EPIPE) and we
+  // return 2.
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
 
@@ -122,7 +130,8 @@ int take_builtin(WORD_LIST *list) {
   // === ANCHOR:ARGV-PARSE-BEGIN ===
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!end_opts && !have_n && strcmp(tok, "--help") == 0) {
       rc = take_help();
@@ -188,12 +197,11 @@ out:
   // === ANCHOR:CLEANUP-END ===
 }
 
-__attribute__((visibility("default")))
-struct builtin take_struct = {
-  .name = "take",
-  .function = take_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = take_doc,
-  .short_doc = (char *)"take N [S] [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin take_struct = {
+    .name = "take",
+    .function = take_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = take_doc,
+    .short_doc = (char *)"take N [S] [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtin_trim.c
+++ b/src/builtins/builtin_trim.c
@@ -3,34 +3,38 @@
 #include "diamondcore.h"
 
 #include <errno.h>
+#include <signal.h> // ANCHOR:SIGPIPE-INCLUDE
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>  // ANCHOR:SIGPIPE-INCLUDE
 
 // Bash loadable builtin headers (vendored minimal subset for loadables)
 #include "builtins.h"
 #include "shell.h"
 
-__attribute__((unused))
-static const char *trim_shortdoc = "trim [--] [FILE...]";
+__attribute__((unused)) static const char *trim_shortdoc =
+    "trim [--] [FILE...]";
 
 static char *trim_doc[] = {
-  "Remove leading and trailing ASCII whitespace from each input line.",
-  (char *)0,
+    "Remove leading and trailing ASCII whitespace from each input line.",
+    (char *)0,
 };
 
 static int trim_usage_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "trim: %s\n", msg);
-  else dc_print_usage_trim(stderr);
+  if (msg && *msg)
+    fprintf(stderr, "trim: %s\n", msg);
+  else
+    dc_print_usage_trim(stderr);
   return 2;
 }
 
 static int trim_io_err(const char *msg) {
-  if (msg && *msg) fprintf(stderr, "trim: %s\n", msg);
-  else fprintf(stderr, "trim: I/O error\n");
+  if (msg && *msg)
+    fprintf(stderr, "trim: %s\n", msg);
+  else
+    fprintf(stderr, "trim: I/O error\n");
   return 2;
 }
 
@@ -67,16 +71,20 @@ static int trim_main(char *const *files, size_t file_count) {
 
     // Exclude trailing '\n' from trim region; newline is structural.
     size_t content_len = v.len;
-    if (v.ends_with_nl && content_len > 0) content_len -= 1;
+    if (v.ends_with_nl && content_len > 0)
+      content_len -= 1;
 
     size_t start = 0;
-    while (start < content_len && is_trim_ws(v.ptr[start])) start++;
+    while (start < content_len && is_trim_ws(v.ptr[start]))
+      start++;
 
     size_t end = content_len;
-    while (end > start && is_trim_ws(v.ptr[end - 1])) end--;
+    while (end > start && is_trim_ws(v.ptr[end - 1]))
+      end--;
 
     size_t out_len = end - start;
-    if (out_len == 0) continue; // emit nothing for this line
+    if (out_len == 0)
+      continue; // emit nothing for this line
 
     size_t n = fwrite(v.ptr + start, 1, out_len, stdout);
     if (n != out_len) {
@@ -108,10 +116,10 @@ static int trim_main(char *const *files, size_t file_count) {
 // Parsing rules:
 // - Only --help is recognized.
 // - Any other -x token is an error unless after --, or token is exactly '-'.
-__attribute__((visibility("default")))
-int trim_builtin(WORD_LIST *list) {
+__attribute__((visibility("default"))) int trim_builtin(WORD_LIST *list) {
   // === ANCHOR:SIGPIPE-BEGIN ===
-  // Ignore SIGPIPE so closed-pipe writes surface as stdio errors (EPIPE) and we return 2.
+  // Ignore SIGPIPE so closed-pipe writes surface as stdio errors (EPIPE) and we
+  // return 2.
   void (*old_sigpipe)(int) = signal(SIGPIPE, SIG_IGN);
   // === ANCHOR:SIGPIPE-END ===
 
@@ -129,7 +137,8 @@ int trim_builtin(WORD_LIST *list) {
 
   for (WORD_LIST *w = list; w; w = w->next) {
     const char *tok = w->word->word;
-    if (!tok) tok = "";
+    if (!tok)
+      tok = "";
 
     if (!end_opts && strcmp(tok, "--help") == 0) {
       rc = trim_help();
@@ -166,12 +175,11 @@ out:
   return rc;
 }
 
-__attribute__((visibility("default")))
-struct builtin trim_struct = {
-  .name = "trim",
-  .function = trim_builtin,
-  .flags = BUILTIN_ENABLED,
-  .long_doc = trim_doc,
-  .short_doc = (char *)"trim [--] [FILE...]",
-  .handle = 0,
+__attribute__((visibility("default"))) struct builtin trim_struct = {
+    .name = "trim",
+    .function = trim_builtin,
+    .flags = BUILTIN_ENABLED,
+    .long_doc = trim_doc,
+    .short_doc = (char *)"trim [--] [FILE...]",
+    .handle = 0,
 };

--- a/src/builtins/builtins.h
+++ b/src/builtins/builtins.h
@@ -3,8 +3,8 @@
  *
  * Minimal Bash loadable builtin interface.
  *
- * The runtime `enable -f` loader expects a global `struct builtin <name>_struct`
- * symbol with the layout below.
+ * The runtime `enable -f` loader expects a global `struct builtin
+ * <name>_struct` symbol with the layout below.
  */
 
 #ifndef BD_VENDORED_BUILTINS_H

--- a/src/builtins/shell.h
+++ b/src/builtins/shell.h
@@ -1,9 +1,9 @@
 /*
  * shell.h (vendored minimal)
  *
- * This project builds Bash loadable builtins. Normally these types come from the
- * Bash source headers. Many environments (including CI containers) do not ship
- * them.
+ * This project builds Bash loadable builtins. Normally these types come from
+ * the Bash source headers. Many environments (including CI containers) do not
+ * ship them.
  *
  * The definitions below are the minimal subset required by our builtins and are
  * consistent with Bash 5.2's loadable builtin ABI.

--- a/src/diamondcore/err.c
+++ b/src/diamondcore/err.c
@@ -7,16 +7,19 @@
 #include <string.h>
 
 void dc_err_init(dc_error_t *err) {
-  if (!err) return;
+  if (!err)
+    return;
   err->code = DC_ERR_NONE;
   err->msg[0] = '\0';
 }
 
 void dc_err_set(dc_error_t *err, dc_err_code_t code, const char *fmt, ...) {
-  if (!err) return;
+  if (!err)
+    return;
   err->code = code;
   err->msg[0] = '\0';
-  if (!fmt) return;
+  if (!fmt)
+    return;
   va_list ap;
   va_start(ap, fmt);
   vsnprintf(err->msg, sizeof(err->msg), fmt, ap);
@@ -26,7 +29,8 @@ void dc_err_set(dc_error_t *err, dc_err_code_t code, const char *fmt, ...) {
 }
 
 int dc_exit_code_from_error(const dc_error_t *err) {
-  if (!err) return 2;
+  if (!err)
+    return 2;
   switch (err->code) {
   case DC_ERR_NONE:
     return 0;

--- a/src/diamondcore/help_common.c
+++ b/src/diamondcore/help_common.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 
 void dc_print_help_common_exit_codes(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("Exit codes:\n", out);
   fputs("  0  success with output\n", out);
   fputs("  1  valid execution, no result\n", out);
@@ -13,7 +14,8 @@ void dc_print_help_common_exit_codes(FILE *out) {
 }
 
 void dc_print_help_common_files(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("Input:\n", out);
   fputs("  - Reads FILE... left-to-right; if no FILE, reads stdin.\n", out);
   fputs("  - A filename of '-' means stdin at that position.\n", out);
@@ -21,15 +23,22 @@ void dc_print_help_common_files(FILE *out) {
 }
 
 void dc_print_help_common_sigpipe(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("Notes:\n", out);
-  fputs("  - SIGPIPE is ignored internally; a closed stdout is a controlled error (exit 2).\n", out);
+  fputs("  - SIGPIPE is ignored internally; a closed stdout is a controlled "
+        "error (exit 2).\n",
+        out);
 }
 
-void dc_print_help_common_range_spec(FILE *out, const char *what, const char *scope) {
-  if (!out) out = stdout;
-  if (!what) what = "SPEC";
-  if (!scope) scope = "";
+void dc_print_help_common_range_spec(FILE *out, const char *what,
+                                     const char *scope) {
+  if (!out)
+    out = stdout;
+  if (!what)
+    what = "SPEC";
+  if (!scope)
+    scope = "";
 
   fprintf(out, "%s:\n", what);
   if (scope[0]) {
@@ -42,5 +51,7 @@ void dc_print_help_common_range_spec(FILE *out, const char *what, const char *sc
   fputs("    ..B      open start\n", out);
   fputs("    A..      open end\n", out);
   fputs("  Whitespace is allowed around ',' and '..'.\n", out);
-  fputs("  Normalized: sorted, deduped, merged; reversed ranges and leading zeros are errors.\n", out);
+  fputs("  Normalized: sorted, deduped, merged; reversed ranges and leading "
+        "zeros are errors.\n",
+        out);
 }

--- a/src/diamondcore/help_count.c
+++ b/src/diamondcore/help_count.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 
 void dc_print_help_count(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: count [--] [FILE...]\n", out);
   fputs("       count --help\n", out);
@@ -19,11 +20,14 @@ void dc_print_help_count(FILE *out) {
   fputs("\n", out);
   fputs("Input:\n", out);
   fputs("  - Input is processed as a sequence of lines.\n", out);
-  fputs("  - A line ends in '\\n', or is the final unterminated line at EOF.\n", out);
+  fputs("  - A line ends in '\\n', or is the final unterminated line at EOF.\n",
+        out);
   fputs("  - The final unterminated line counts as a line.\n", out);
   fputs("\n", out);
   fputs("Output:\n", out);
-  fputs("  - Prints the line count as base-10 unsigned decimal followed by '\\n'.\n", out);
+  fputs("  - Prints the line count as base-10 unsigned decimal followed by "
+        "'\\n'.\n",
+        out);
   fputs("\n", out);
   fputs("Exit codes:\n", out);
   fputs("  0  success (count printed)\n", out);

--- a/src/diamondcore/help_fields.c
+++ b/src/diamondcore/help_fields.c
@@ -5,20 +5,24 @@
 #include <stdio.h>
 
 void dc_print_help_fields(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: fields SPEC [FILE...]\n", out);
   fputs("       fields [--tsv] [-d DELIM] SPEC [--] [FILE...]\n", out);
   fputs("       fields --help\n", out);
   fputs("\n", out);
   fputs("Select and emit specific 1-based fields from each input line.\n", out);
-  fputs("Default splitting is ASCII whitespace; -d enables single-byte delimiter splitting.\n", out);
+  fputs("Default splitting is ASCII whitespace; -d enables single-byte "
+        "delimiter splitting.\n",
+        out);
   fputs("\n", out);
 
   fputs("Options:\n", out);
   fputs("  --help        print this help and exit 0\n", out);
   fputs("  --            end option parsing\n", out);
-  fputs("  --tsv         join selected fields with a single TAB byte (0x09)\n", out);
+  fputs("  --tsv         join selected fields with a single TAB byte (0x09)\n",
+        out);
   fputs("  -d DELIM      delimiter mode; DELIM must be exactly 1 byte\n", out);
   fputs("               accepted forms: -dX  or  -d X\n", out);
   fputs("\n", out);
@@ -28,22 +32,33 @@ void dc_print_help_fields(FILE *out) {
   fputs("  FILE...       optional inputs\n", out);
   fputs("\n", out);
 
-  dc_print_help_common_range_spec(out, "SPEC", "Applies independently to each input line.");
+  dc_print_help_common_range_spec(out, "SPEC",
+                                  "Applies independently to each input line.");
   fputs("\n", out);
 
   dc_print_help_common_files(out);
   fputs("\n", out);
 
   fputs("Splitting:\n", out);
-  fputs("  Whitespace mode: ASCII whitespace delimits fields; runs collapse; no empty fields.\n", out);
-  fputs("  -d mode: splits on DELIM; empty fields are preserved between consecutive delimiters.\n", out);
+  fputs("  Whitespace mode: ASCII whitespace delimits fields; runs collapse; "
+        "no empty fields.\n",
+        out);
+  fputs("  -d mode: splits on DELIM; empty fields are preserved between "
+        "consecutive delimiters.\n",
+        out);
   fputs("\n", out);
 
   fputs("Output:\n", out);
   fputs("  - Selected fields are emitted in ascending order.\n", out);
-  fputs("  - Join delimiter is a single space by default; with --tsv it is a single TAB byte.\n", out);
-  fputs("  - If at least one field is selected for a line: emits that output line.\n", out);
-  fputs("  - Output newline is preserved from the input line when an output line is emitted.\n", out);
+  fputs("  - Join delimiter is a single space by default; with --tsv it is a "
+        "single TAB byte.\n",
+        out);
+  fputs("  - If at least one field is selected for a line: emits that output "
+        "line.\n",
+        out);
+  fputs("  - Output newline is preserved from the input line when an output "
+        "line is emitted.\n",
+        out);
   fputs("\n", out);
 
   dc_print_help_common_exit_codes(out);

--- a/src/diamondcore/help_filter.c
+++ b/src/diamondcore/help_filter.c
@@ -5,13 +5,18 @@
 #include <stdio.h>
 
 void dc_print_help_filter(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: filter EXPR [--] [FILE...]\n", out);
   fputs("       filter --help\n", out);
   fputs("\n", out);
-  fputs("Select input lines whose fields satisfy a constrained boolean expression.\n", out);
-  fputs("Fields are delimited by a single TAB byte (0x09); no quoting, no trimming.\n", out);
+  fputs("Select input lines whose fields satisfy a constrained boolean "
+        "expression.\n",
+        out);
+  fputs("Fields are delimited by a single TAB byte (0x09); no quoting, no "
+        "trimming.\n",
+        out);
   fputs("\n", out);
 
   fputs("Options:\n", out);
@@ -20,7 +25,8 @@ void dc_print_help_filter(FILE *out) {
   fputs("\n", out);
 
   fputs("Arguments:\n", out);
-  fputs("  EXPR     constrained boolean expression (see docs/filter.md)\n", out);
+  fputs("  EXPR     constrained boolean expression (see docs/filter.md)\n",
+        out);
   fputs("  FILE...  optional inputs\n", out);
   fputs("\n", out);
 
@@ -28,12 +34,16 @@ void dc_print_help_filter(FILE *out) {
   fputs("\n", out);
 
   fputs("Output:\n", out);
-  fputs("  - Matching lines are written verbatim (including their newline if present).\n", out);
+  fputs("  - Matching lines are written verbatim (including their newline if "
+        "present).\n",
+        out);
   fputs("  - No newline is synthesized.\n", out);
   fputs("\n", out);
 
   fputs("Errors:\n", out);
-  fputs("  - Expression parse errors, evaluation limit exceeded, I/O errors => exit 2.\n", out);
+  fputs("  - Expression parse errors, evaluation limit exceeded, I/O errors => "
+        "exit 2.\n",
+        out);
   fputs("\n", out);
 
   dc_print_help_common_exit_codes(out);

--- a/src/diamondcore/help_lines.c
+++ b/src/diamondcore/help_lines.c
@@ -5,12 +5,15 @@
 #include <stdio.h>
 
 void dc_print_help_lines(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: lines SPEC [--] [FILE...]\n", out);
   fputs("       lines --help\n", out);
   fputs("\n", out);
-  fputs("Select and emit specific 1-based input lines by numeric index or range.\n", out);
+  fputs("Select and emit specific 1-based input lines by numeric index or "
+        "range.\n",
+        out);
   fputs("\n", out);
 
   fputs("Options:\n", out);
@@ -23,14 +26,17 @@ void dc_print_help_lines(FILE *out) {
   fputs("  FILE...  optional inputs\n", out);
   fputs("\n", out);
 
-  dc_print_help_common_range_spec(out, "SPEC", "Applies to the concatenation of all inputs.");
+  dc_print_help_common_range_spec(
+      out, "SPEC", "Applies to the concatenation of all inputs.");
   fputs("\n", out);
 
   dc_print_help_common_files(out);
   fputs("\n", out);
 
   fputs("Output:\n", out);
-  fputs("  - Matching lines are written verbatim (including their newline if present).\n", out);
+  fputs("  - Matching lines are written verbatim (including their newline if "
+        "present).\n",
+        out);
   fputs("  - No newline is synthesized.\n", out);
   fputs("\n", out);
 

--- a/src/diamondcore/help_match.c
+++ b/src/diamondcore/help_match.c
@@ -5,13 +5,16 @@
 #include <stdio.h>
 
 void dc_print_help_match(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: match PATTERN [--] [FILE...]\n", out);
   fputs("       match --help\n", out);
   fputs("\n", out);
   fputs("Filter input lines by a deterministic, constrained regex.\n", out);
-  fputs("Matches are evaluated on the line content excluding a terminating '\\n'.\n", out);
+  fputs("Matches are evaluated on the line content excluding a terminating "
+        "'\\n'.\n",
+        out);
   fputs("\n", out);
 
   fputs("Options:\n", out);
@@ -25,22 +28,32 @@ void dc_print_help_match(FILE *out) {
   fputs("\n", out);
 
   fputs("Pattern features (subset):\n", out);
-  fputs("  Literals, '.', character classes [...], grouping (...), alternation '|'.\n", out);
+  fputs("  Literals, '.', character classes [...], grouping (...), alternation "
+        "'|'.\n",
+        out);
   fputs("  Quantifiers: '*', '+', '?'.\n", out);
-  fputs("  Anchors: '^' at start, '$' at end (otherwise literal unless escaped).\n", out);
-  fputs("  Only specific escapes are accepted (e.g. \\., \\[, \\], \\^, \\$).\n", out);
+  fputs("  Anchors: '^' at start, '$' at end (otherwise literal unless "
+        "escaped).\n",
+        out);
+  fputs(
+      "  Only specific escapes are accepted (e.g. \\., \\[, \\], \\^, \\$).\n",
+      out);
   fputs("\n", out);
 
   dc_print_help_common_files(out);
   fputs("\n", out);
 
   fputs("Output:\n", out);
-  fputs("  - Matching lines are written verbatim (including their newline if present).\n", out);
+  fputs("  - Matching lines are written verbatim (including their newline if "
+        "present).\n",
+        out);
   fputs("  - No newline is synthesized.\n", out);
   fputs("\n", out);
 
   fputs("Errors:\n", out);
-  fputs("  - Pattern compile errors and execution limit exceeded return exit 2.\n", out);
+  fputs("  - Pattern compile errors and execution limit exceeded return exit "
+        "2.\n",
+        out);
   fputs("\n", out);
 
   dc_print_help_common_exit_codes(out);

--- a/src/diamondcore/help_replace.c
+++ b/src/diamondcore/help_replace.c
@@ -6,7 +6,8 @@
 #include <stdio.h>
 
 void dc_print_help_replace(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: replace [--literal] PATTERN REPLACEMENT [--] [FILE...]\n", out);
   fputs("       replace --help\n", out);
@@ -16,13 +17,21 @@ void dc_print_help_replace(FILE *out) {
   fputs("\n", out);
 
   fputs("Description:\n", out);
-  fputs("  replace processes input record-by-record (records are delimited by 0x0A when present).\n", out);
-  fputs("  Matching and replacement operate on the record content excluding a terminating '\\n'.\n", out);
-  fputs("  If a record changes (>=1 substitution), the modified record is written; otherwise it is skipped.\n", out);
+  fputs("  replace processes input record-by-record (records are delimited by "
+        "0x0A when present).\n",
+        out);
+  fputs("  Matching and replacement operate on the record content excluding a "
+        "terminating '\\n'.\n",
+        out);
+  fputs("  If a record changes (>=1 substitution), the modified record is "
+        "written; otherwise it is skipped.\n",
+        out);
   fputs("\n", out);
 
   fputs("Options:\n", out);
-  fputs("  --literal   Treat PATTERN as a literal byte sequence (no regex metacharacters).\n", out);
+  fputs("  --literal   Treat PATTERN as a literal byte sequence (no regex "
+        "metacharacters).\n",
+        out);
   fputs("  --help      Show this help and exit.\n", out);
   fputs("  --          End option parsing.\n", out);
   fputs("\n", out);
@@ -30,13 +39,19 @@ void dc_print_help_replace(FILE *out) {
   fputs("Exit codes:\n", out);
   fputs("  0  At least one modified record was written.\n", out);
   fputs("  1  No substitutions occurred (no output).\n", out);
-  fputs("  2  Usage error or runtime error (including I/O and write failures).\n", out);
+  fputs(
+      "  2  Usage error or runtime error (including I/O and write failures).\n",
+      out);
   fputs("\n", out);
 
   fputs("Streaming model:\n", out);
-  fputs("  Only the current record is buffered; the entire input is never buffered.\n", out);
+  fputs("  Only the current record is buffered; the entire input is never "
+        "buffered.\n",
+        out);
   fputs("\n", out);
 
   fputs("SIGPIPE:\n", out);
-  fputs("  SIGPIPE is ignored internally. If writing to stdout fails, replace exits 2.\n", out);
+  fputs("  SIGPIPE is ignored internally. If writing to stdout fails, replace "
+        "exits 2.\n",
+        out);
 }

--- a/src/diamondcore/help_table.c
+++ b/src/diamondcore/help_table.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 
 void dc_print_help_table(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: table [--] [FILE...]\n", out);
   fputs("       table --help\n", out);
@@ -23,16 +24,24 @@ void dc_print_help_table(FILE *out) {
   fputs("\n", out);
 
   fputs("Input:\n", out);
-  fputs("  - Fields are split by runs of spaces and tabs (leading/trailing ignored).\n", out);
+  fputs("  - Fields are split by runs of spaces and tabs (leading/trailing "
+        "ignored).\n",
+        out);
   fputs("  - Empty/whitespace-only lines are not emitted.\n", out);
-  fputs("  - stdin (including '-') is not supported (non-seekable input).\n", out);
+  fputs("  - stdin (including '-') is not supported (non-seekable input).\n",
+        out);
   fputs("\n", out);
 
   fputs("Output:\n", out);
-  fputs("  - Columns are padded with spaces to align to the maximum width per column.\n", out);
-  fputs("  - Minimum column separation: 1 space after column 1; 2 spaces after later columns.\n", out);
+  fputs("  - Columns are padded with spaces to align to the maximum width per "
+        "column.\n",
+        out);
+  fputs("  - Minimum column separation: 1 space after column 1; 2 spaces after "
+        "later columns.\n",
+        out);
   fputs("  - No trailing spaces are written.\n", out);
-  fputs("  - Newlines are preserved only when an input line is emitted.\n", out);
+  fputs("  - Newlines are preserved only when an input line is emitted.\n",
+        out);
   fputs("\n", out);
 
   dc_print_help_common_exit_codes(out);

--- a/src/diamondcore/help_take.c
+++ b/src/diamondcore/help_take.c
@@ -5,13 +5,16 @@
 #include <stdio.h>
 
 void dc_print_help_take(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: take N [S] [--] [FILE...]\n", out);
   fputs("       take --help\n", out);
   fputs("\n", out);
   fputs("Emit a forward-only slice of input lines.\n", out);
-  fputs("take N emits the first N lines; take N S skips S lines then emits N lines.\n", out);
+  fputs("take N emits the first N lines; take N S skips S lines then emits N "
+        "lines.\n",
+        out);
   fputs("\n", out);
 
   fputs("Options:\n", out);
@@ -20,8 +23,11 @@ void dc_print_help_take(FILE *out) {
   fputs("\n", out);
 
   fputs("Arguments:\n", out);
-  fputs("  N        number of lines to emit (uint64, base-10, 0 allowed)\n", out);
-  fputs("  S        number of lines to skip (uint64, base-10, 0 allowed; default 0)\n", out);
+  fputs("  N        number of lines to emit (uint64, base-10, 0 allowed)\n",
+        out);
+  fputs("  S        number of lines to skip (uint64, base-10, 0 allowed; "
+        "default 0)\n",
+        out);
   fputs("  FILE...  optional inputs\n", out);
   fputs("\n", out);
 
@@ -35,7 +41,9 @@ void dc_print_help_take(FILE *out) {
   fputs("\n", out);
 
   fputs("Output:\n", out);
-  fputs("  - Selected lines are written verbatim (including their newline if present).\n", out);
+  fputs("  - Selected lines are written verbatim (including their newline if "
+        "present).\n",
+        out);
   fputs("  - No newline is synthesized.\n", out);
   fputs("  - Stops reading once N lines have been emitted.\n", out);
   fputs("\n", out);

--- a/src/diamondcore/help_trim.c
+++ b/src/diamondcore/help_trim.c
@@ -5,12 +5,14 @@
 #include <stdio.h>
 
 void dc_print_help_trim(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
 
   fputs("usage: trim [--] [FILE...]\n", out);
   fputs("       trim --help\n", out);
   fputs("\n", out);
-  fputs("Remove leading and trailing ASCII whitespace from each input line.\n", out);
+  fputs("Remove leading and trailing ASCII whitespace from each input line.\n",
+        out);
   fputs("Lines that become empty after trimming are not emitted.\n", out);
   fputs("\n", out);
 
@@ -28,11 +30,15 @@ void dc_print_help_trim(FILE *out) {
 
   fputs("Trimming:\n", out);
   fputs("  - Trims ASCII: space, tab, CR, VT, FF.\n", out);
-  fputs("  - Newline is structural and preserved only when a line is emitted.\n", out);
+  fputs(
+      "  - Newline is structural and preserved only when a line is emitted.\n",
+      out);
   fputs("\n", out);
 
   fputs("Output:\n", out);
-  fputs("  - If trimmed content is non-empty: emits it; preserves trailing newline if present.\n", out);
+  fputs("  - If trimmed content is non-empty: emits it; preserves trailing "
+        "newline if present.\n",
+        out);
   fputs("  - If trimmed content is empty: emits nothing for that line.\n", out);
   fputs("\n", out);
 

--- a/src/diamondcore/io.c
+++ b/src/diamondcore/io.c
@@ -2,11 +2,11 @@
 
 #include "diamondcore.h"
 
-#include <sys/types.h>  /* ssize_t */
-#include <stdio.h>      /* getline */
 #include <errno.h>
+#include <stdio.h> /* getline */
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h> /* ssize_t */
 
 struct dc_line_reader {
   char **files;
@@ -19,14 +19,16 @@ struct dc_line_reader {
 };
 
 static bool open_next(dc_line_reader_t *lr, dc_error_t *err) {
-  if (!lr) return false;
+  if (!lr)
+    return false;
   if (lr->fp && !lr->fp_is_stdin) {
     fclose(lr->fp);
   }
   lr->fp = NULL;
   lr->fp_is_stdin = false;
 
-  if (lr->idx >= lr->file_count) return false;
+  if (lr->idx >= lr->file_count)
+    return false;
 
   const char *name = lr->files[lr->idx++];
   if (strcmp(name, "-") == 0) {
@@ -43,9 +45,11 @@ static bool open_next(dc_line_reader_t *lr, dc_error_t *err) {
   return true;
 }
 
-dc_line_reader_t *dc_lr_open(char *const *files, size_t file_count, dc_error_t *err) {
+dc_line_reader_t *dc_lr_open(char *const *files, size_t file_count,
+                             dc_error_t *err) {
   dc_err_init(err);
-  dc_line_reader_t *lr = (dc_line_reader_t *)calloc(1, sizeof(dc_line_reader_t));
+  dc_line_reader_t *lr =
+      (dc_line_reader_t *)calloc(1, sizeof(dc_line_reader_t));
   if (!lr) {
     dc_err_set(err, DC_ERR_NOMEM, "out of memory");
     return NULL;
@@ -68,7 +72,8 @@ dc_line_reader_t *dc_lr_open(char *const *files, size_t file_count, dc_error_t *
       dc_err_set(err, DC_ERR_NOMEM, "out of memory");
       return NULL;
     }
-    for (size_t i = 0; i < file_count; i++) lr->files[i] = files[i];
+    for (size_t i = 0; i < file_count; i++)
+      lr->files[i] = files[i];
     lr->file_count = file_count;
   }
 
@@ -108,7 +113,8 @@ bool dc_lr_next(dc_line_reader_t *lr, dc_line_view_t *out, dc_error_t *err) {
     // n < 0
     if (feof(lr->fp)) {
       // Move to next source.
-      if (lr->fp && !lr->fp_is_stdin) fclose(lr->fp);
+      if (lr->fp && !lr->fp_is_stdin)
+        fclose(lr->fp);
       lr->fp = NULL;
       lr->fp_is_stdin = false;
       continue;
@@ -121,8 +127,10 @@ bool dc_lr_next(dc_line_reader_t *lr, dc_line_view_t *out, dc_error_t *err) {
 }
 
 void dc_lr_close(dc_line_reader_t *lr) {
-  if (!lr) return;
-  if (lr->fp && !lr->fp_is_stdin) fclose(lr->fp);
+  if (!lr)
+    return;
+  if (lr->fp && !lr->fp_is_stdin)
+    fclose(lr->fp);
   free(lr->files);
   free(lr->buf);
   free(lr);

--- a/src/diamondcore/range.c
+++ b/src/diamondcore/range.c
@@ -15,8 +15,8 @@ typedef struct {
 
 struct dc_sel {
   dc_range_t *ranges;
-  size_t      nranges;
-  size_t      cap;
+  size_t nranges;
+  size_t cap;
 
   /* Streaming cursor: monotone line_no => monotone range index */
   size_t cursor;
@@ -25,11 +25,13 @@ struct dc_sel {
 static inline bool is_ws(char c) { return c == ' ' || c == '\t'; }
 
 static void skip_ws(const char **p) {
-  while (p && *p && **p && is_ws(**p)) (*p)++;
+  while (p && *p && **p && is_ws(**p))
+    (*p)++;
 }
 
 static bool add_range(dc_sel_t *sel, uint64_t a, uint64_t b, dc_error_t *err) {
-  if (!sel) return false;
+  if (!sel)
+    return false;
   if (sel->nranges == sel->cap) {
     size_t newcap = sel->cap ? sel->cap * 2 : 8;
     void *np = realloc(sel->ranges, newcap * sizeof(dc_range_t));
@@ -40,7 +42,7 @@ static bool add_range(dc_sel_t *sel, uint64_t a, uint64_t b, dc_error_t *err) {
     sel->ranges = (dc_range_t *)np;
     sel->cap = newcap;
   }
-  sel->ranges[sel->nranges++] = (dc_range_t){ .start = a, .end = b };
+  sel->ranges[sel->nranges++] = (dc_range_t){.start = a, .end = b};
   return true;
 }
 
@@ -81,14 +83,16 @@ static bool parse_uint_strict(const char **p, uint64_t *out, dc_error_t *err) {
     v = v * 10 + d;
   }
 
-  /* No whitespace inside UINT; caller handles allowed whitespace at boundaries. */
+  /* No whitespace inside UINT; caller handles allowed whitespace at boundaries.
+   */
   *out = v;
   *p = s;
   return true;
 }
 
 static bool match_dots(const char **p) {
-  if (!p || !*p) return false;
+  if (!p || !*p)
+    return false;
 
   const char *s = *p;
   if (s && s[0] == '.' && s[1] == '.') {
@@ -118,7 +122,8 @@ static bool parse_item(const char **p, dc_sel_t *sel, dc_error_t *err) {
   uint64_t start = 0, end = 0;
   bool have_start = false, have_end = false;
 
-  /* Two cases: (1) starts with ".." => open-start range; (2) starts with UINT */
+  /* Two cases: (1) starts with ".." => open-start range; (2) starts with UINT
+   */
   if (match_dots(p)) {
     /* "..END" form; START is ε */
     skip_ws(p);
@@ -131,7 +136,8 @@ static bool parse_item(const char **p, dc_sel_t *sel, dc_error_t *err) {
       dc_err_set(err, DC_ERR_USAGE, "lines: invalid SPEC");
       return false;
     }
-    if (!parse_uint_strict(p, &end, err)) return false;
+    if (!parse_uint_strict(p, &end, err))
+      return false;
     have_end = true;
 
     /* Range is 1..end */
@@ -147,7 +153,8 @@ static bool parse_item(const char **p, dc_sel_t *sel, dc_error_t *err) {
     dc_err_set(err, DC_ERR_USAGE, "lines: invalid SPEC");
     return false;
   }
-  if (!parse_uint_strict(p, &start, err)) return false;
+  if (!parse_uint_strict(p, &start, err))
+    return false;
   have_start = true;
 
   /* If it's an INDEX, we're done unless a RANGE follows */
@@ -165,7 +172,8 @@ static bool parse_item(const char **p, dc_sel_t *sel, dc_error_t *err) {
   skip_ws(p);
   if (p && *p && **p != '\0') {
     if ((**p >= '0' && **p <= '9')) {
-      if (!parse_uint_strict(p, &end, err)) return false;
+      if (!parse_uint_strict(p, &end, err))
+        return false;
       have_end = true;
     }
   }
@@ -199,16 +207,21 @@ static bool parse_item(const char **p, dc_sel_t *sel, dc_error_t *err) {
 static int cmp_range(const void *A, const void *B) {
   const dc_range_t *a = (const dc_range_t *)A;
   const dc_range_t *b = (const dc_range_t *)B;
-  if (a->start < b->start) return -1;
-  if (a->start > b->start) return 1;
-  if (a->end < b->end) return -1;
-  if (a->end > b->end) return 1;
+  if (a->start < b->start)
+    return -1;
+  if (a->start > b->start)
+    return 1;
+  if (a->end < b->end)
+    return -1;
+  if (a->end > b->end)
+    return 1;
   return 0;
 }
 
 /* Merge ranges in-place; assumes sorted by (start,end). */
 static void normalize_ranges(dc_sel_t *sel) {
-  if (!sel || sel->nranges == 0) return;
+  if (!sel || sel->nranges == 0)
+    return;
 
   qsort(sel->ranges, sel->nranges, sizeof(dc_range_t), cmp_range);
 
@@ -250,7 +263,8 @@ static void normalize_ranges(dc_sel_t *sel) {
 }
 
 dc_sel_t *dc_sel_parse_and_normalize(const char *spec, dc_error_t *err) {
-  if (err) memset(err,0, sizeof(*err));
+  if (err)
+    memset(err, 0, sizeof(*err));
 
   if (!spec || *spec == '\0') {
     dc_err_set(err, DC_ERR_USAGE, "lines: invalid SPEC");
@@ -286,7 +300,8 @@ dc_sel_t *dc_sel_parse_and_normalize(const char *spec, dc_error_t *err) {
 
     skip_ws(&p);
 
-    if (*p == '\0') break;
+    if (*p == '\0')
+      break;
 
     if (*p != ',') {
       /* Any junk between items is invalid (incl letters, extra dots, etc.) */
@@ -318,40 +333,50 @@ dc_sel_t *dc_sel_parse_and_normalize(const char *spec, dc_error_t *err) {
 }
 
 bool dc_sel_wants(dc_sel_t *sel, uint64_t line_no) {
-  if (!sel || sel->nranges == 0) return false;
+  if (!sel || sel->nranges == 0)
+    return false;
 
   /* Advance cursor while line_no is beyond current range end */
   while (sel->cursor < sel->nranges) {
     dc_range_t r = sel->ranges[sel->cursor];
-    if (line_no < r.start) return false;
-    if (r.end == UINT64_MAX) return true;
-    if (line_no <= r.end) return true;
+    if (line_no < r.start)
+      return false;
+    if (r.end == UINT64_MAX)
+      return true;
+    if (line_no <= r.end)
+      return true;
     sel->cursor++;
   }
   return false;
 }
 
 uint64_t dc_sel_max_finite(dc_sel_t *sel, bool *has_max) {
-  if (has_max) *has_max = false;
-  if (!sel || sel->nranges == 0) return 0;
+  if (has_max)
+    *has_max = false;
+  if (!sel || sel->nranges == 0)
+    return 0;
 
   for (size_t i = 0; i < sel->nranges; i++) {
     if (sel->ranges[i].end == UINT64_MAX) {
-      if (has_max) *has_max = false;
+      if (has_max)
+        *has_max = false;
       return 0;
     }
   }
 
   uint64_t m = 0;
   for (size_t i = 0; i < sel->nranges; i++) {
-    if (sel->ranges[i].end > m) m = sel->ranges[i].end;
+    if (sel->ranges[i].end > m)
+      m = sel->ranges[i].end;
   }
-  if (has_max) *has_max = true;
+  if (has_max)
+    *has_max = true;
   return m;
 }
 
 void dc_sel_free(dc_sel_t *sel) {
-  if (!sel) return;
+  if (!sel)
+    return;
   free(sel->ranges);
   free(sel);
 }

--- a/src/diamondcore/regex.c
+++ b/src/diamondcore/regex.c
@@ -1,8 +1,8 @@
 #include "dc_regex.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 typedef enum {
   I_MATCH = 0,
@@ -41,9 +41,16 @@ struct dc_regex {
   /* program allocated size fixed at max */
 };
 
-static void bitset_set(uint8_t bits[32], uint8_t b) { bits[b >> 3] |= (uint8_t)(1u << (b & 7)); }
-static bool bitset_test(const uint8_t bits[32], uint8_t b) { return (bits[b >> 3] & (uint8_t)(1u << (b & 7))) != 0; }
-static void bitset_invert(uint8_t bits[32]) { for (int i = 0; i < 32; i++) bits[i] = (uint8_t)~bits[i]; }
+static void bitset_set(uint8_t bits[32], uint8_t b) {
+  bits[b >> 3] |= (uint8_t)(1u << (b & 7));
+}
+static bool bitset_test(const uint8_t bits[32], uint8_t b) {
+  return (bits[b >> 3] & (uint8_t)(1u << (b & 7))) != 0;
+}
+static void bitset_invert(uint8_t bits[32]) {
+  for (int i = 0; i < 32; i++)
+    bits[i] = (uint8_t)~bits[i];
+}
 
 typedef struct {
   int *p;
@@ -51,14 +58,23 @@ typedef struct {
   int cap;
 } plist_t;
 
-static void plist_init(plist_t *pl) { pl->p = NULL; pl->n = 0; pl->cap = 0; }
-static void plist_free(plist_t *pl) { free(pl->p); pl->p = NULL; pl->n = pl->cap = 0; }
+static void plist_init(plist_t *pl) {
+  pl->p = NULL;
+  pl->n = 0;
+  pl->cap = 0;
+}
+static void plist_free(plist_t *pl) {
+  free(pl->p);
+  pl->p = NULL;
+  pl->n = pl->cap = 0;
+}
 
 static bool plist_push(plist_t *pl, int v) {
   if (pl->n == pl->cap) {
     int nc = (pl->cap == 0) ? 16 : pl->cap * 2;
     int *np = (int *)realloc(pl->p, (size_t)nc * sizeof(int));
-    if (!np) return false;
+    if (!np)
+      return false;
     pl->p = np;
     pl->cap = nc;
   }
@@ -67,12 +83,16 @@ static bool plist_push(plist_t *pl, int v) {
 }
 
 static bool plist_append(plist_t *a, const plist_t *b) {
-  for (int i = 0; i < b->n; i++) if (!plist_push(a, b->p[i])) return false;
+  for (int i = 0; i < b->n; i++)
+    if (!plist_push(a, b->p[i]))
+      return false;
   return true;
 }
 
 /* Patch encoding: (inst_index<<1) | field(0=x,1=y) */
-static int patch_field(int inst_index, int field) { return (inst_index << 1) | (field & 1); }
+static int patch_field(int inst_index, int field) {
+  return (inst_index << 1) | (field & 1);
+}
 
 typedef struct {
   int start;
@@ -113,26 +133,31 @@ typedef struct {
 } parser_t;
 
 static void perr(parser_t *ps, const char *msg) {
-  if (!ps->ok) return;
+  if (!ps->ok)
+    return;
   ps->ok = false;
-  if (ps->err) snprintf(ps->err, 256, "%s", msg);
+  if (ps->err)
+    snprintf(ps->err, 256, "%s", msg);
 }
 
 static bool at_end(parser_t *ps) { return ps->i >= ps->len; }
 static char peek(parser_t *ps) { return at_end(ps) ? '\0' : ps->pat[ps->i]; }
-static char getc_ps(parser_t *ps) { return at_end(ps) ? '\0' : ps->pat[ps->i++]; }
+static char getc_ps(parser_t *ps) {
+  return at_end(ps) ? '\0' : ps->pat[ps->i++];
+}
 
 static bool is_quant(char c) { return c == '*' || c == '+' || c == '?'; }
 
 /* Treat unsupported constructs as compile error by making them meta here */
 static bool is_meta(char c) {
-  return c == '.' || c == '*' || c == '+' || c == '?' || c == '|' ||
-         c == '(' || c == ')' || c == '[' || c == ']' || c == '^' ||
-         c == '$' || c == '\\' || c == '{' || c == '}';
+  return c == '.' || c == '*' || c == '+' || c == '?' || c == '|' || c == '(' ||
+         c == ')' || c == '[' || c == ']' || c == '^' || c == '$' ||
+         c == '\\' || c == '{' || c == '}';
 }
 
 static int emit_inst(parser_t *ps, inst_t ins) {
-  if (!ps->ok) return -1;
+  if (!ps->ok)
+    return -1;
   if (ps->re->prog_len >= DC_REGEX_MAX_PROG_INSN) {
     perr(ps, "match: pattern compile error");
     return -1;
@@ -142,11 +167,15 @@ static int emit_inst(parser_t *ps, inst_t ins) {
 }
 
 static int add_class(parser_t *ps, const cls_t *c) {
-  if (!ps->ok) return -1;
+  if (!ps->ok)
+    return -1;
   if (ps->re->class_len == ps->cls_cap) {
     int nc = (ps->cls_cap == 0) ? 16 : ps->cls_cap * 2;
     cls_t *np = (cls_t *)realloc(ps->re->classes, (size_t)nc * sizeof(cls_t));
-    if (!np) { perr(ps, "match: out of memory"); return -1; }
+    if (!np) {
+      perr(ps, "match: out of memory");
+      return -1;
+    }
     ps->re->classes = np;
     ps->cls_cap = nc;
   }
@@ -159,24 +188,38 @@ static void patch(parser_t *ps, const plist_t *pl, int target) {
     int enc = pl->p[i];
     int idx = enc >> 1;
     int fld = enc & 1;
-    if (fld == 0) ps->re->prog[idx].x = target;
-    else ps->re->prog[idx].y = target;
+    if (fld == 0)
+      ps->re->prog[idx].x = target;
+    else
+      ps->re->prog[idx].y = target;
   }
 }
 
 /* only valid escapes: \. \* \+ \? \| \( \) \[ \] \^ \$ \\ */
 static bool parse_escape_outside(parser_t *ps, uint8_t *out) {
-  if (at_end(ps)) { perr(ps, "match: pattern compile error"); return false; }
+  if (at_end(ps)) {
+    perr(ps, "match: pattern compile error");
+    return false;
+  }
   char c = getc_ps(ps);
   switch (c) {
-    case '.': case '*': case '+': case '?': case '|':
-    case '(': case ')': case '[': case ']': case '^':
-    case '$': case '\\':
-      *out = (uint8_t)c;
-      return true;
-    default:
-      perr(ps, "match: pattern compile error");
-      return false;
+  case '.':
+  case '*':
+  case '+':
+  case '?':
+  case '|':
+  case '(':
+  case ')':
+  case '[':
+  case ']':
+  case '^':
+  case '$':
+  case '\\':
+    *out = (uint8_t)c;
+    return true;
+  default:
+    perr(ps, "match: pattern compile error");
+    return false;
   }
 }
 
@@ -192,10 +235,19 @@ static frag_t parse_class(parser_t *ps) {
   bool neg = false;
   bool have_any = false;
 
-  if (at_end(ps)) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
-  if (peek(ps) == '^') { getc_ps(ps); neg = true; }
+  if (at_end(ps)) {
+    perr(ps, "match: pattern compile error");
+    return frag_invalid();
+  }
+  if (peek(ps) == '^') {
+    getc_ps(ps);
+    neg = true;
+  }
 
-  if (at_end(ps) || peek(ps) == ']') { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+  if (at_end(ps) || peek(ps) == ']') {
+    perr(ps, "match: pattern compile error");
+    return frag_invalid();
+  }
 
   int prev_raw = -1;
   int prev_atom = -1;
@@ -204,17 +256,26 @@ static frag_t parse_class(parser_t *ps) {
   while (!at_end(ps)) {
     char c = getc_ps(ps);
 
-    if (prev_raw == '[' && c == ':') { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+    if (prev_raw == '[' && c == ':') {
+      perr(ps, "match: pattern compile error");
+      return frag_invalid();
+    }
     prev_raw = (unsigned char)c;
 
     if (c == ']') {
-      if (!have_any) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+      if (!have_any) {
+        perr(ps, "match: pattern compile error");
+        return frag_invalid();
+      }
       break;
     }
 
     int atom = -1;
     if (c == '\\') {
-      if (at_end(ps)) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+      if (at_end(ps)) {
+        perr(ps, "match: pattern compile error");
+        return frag_invalid();
+      }
       char e = getc_ps(ps);
       if (e == '\\' || e == ']' || e == '-' || e == '^') {
         atom = (unsigned char)e;
@@ -228,7 +289,10 @@ static frag_t parse_class(parser_t *ps) {
     }
 
     if (atom == '-' && prev_atom_valid_for_range) {
-      if (at_end(ps)) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+      if (at_end(ps)) {
+        perr(ps, "match: pattern compile error");
+        return frag_invalid();
+      }
       if (peek(ps) == ']') {
         bitset_set(cls.bits, (uint8_t)'-');
         have_any = true;
@@ -240,11 +304,17 @@ static frag_t parse_class(parser_t *ps) {
       int next_atom = -1;
       char nc = getc_ps(ps);
 
-      if (prev_raw == '[' && nc == ':') { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+      if (prev_raw == '[' && nc == ':') {
+        perr(ps, "match: pattern compile error");
+        return frag_invalid();
+      }
       prev_raw = (unsigned char)nc;
 
       if (nc == '\\') {
-        if (at_end(ps)) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+        if (at_end(ps)) {
+          perr(ps, "match: pattern compile error");
+          return frag_invalid();
+        }
         char ne = getc_ps(ps);
         if (ne == '\\' || ne == ']' || ne == '-' || ne == '^') {
           next_atom = (unsigned char)ne;
@@ -261,8 +331,12 @@ static frag_t parse_class(parser_t *ps) {
         next_atom = (unsigned char)nc;
       }
 
-      if (prev_atom > next_atom) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
-      for (int b = prev_atom; b <= next_atom; b++) bitset_set(cls.bits, (uint8_t)b);
+      if (prev_atom > next_atom) {
+        perr(ps, "match: pattern compile error");
+        return frag_invalid();
+      }
+      for (int b = prev_atom; b <= next_atom; b++)
+        bitset_set(cls.bits, (uint8_t)b);
       have_any = true;
 
       prev_atom = next_atom;
@@ -276,129 +350,227 @@ static frag_t parse_class(parser_t *ps) {
     prev_atom_valid_for_range = true;
   }
 
-  if (neg) bitset_invert(cls.bits);
+  if (neg)
+    bitset_invert(cls.bits);
 
   int cls_id = add_class(ps, &cls);
-  if (cls_id < 0) return frag_invalid();
+  if (cls_id < 0)
+    return frag_invalid();
 
-  inst_t ins; memset(&ins, 0, sizeof(ins));
+  inst_t ins;
+  memset(&ins, 0, sizeof(ins));
   ins.op = I_CLASS;
   ins.cls = (uint16_t)cls_id;
   ins.x = -1;
   int pc = emit_inst(ps, ins);
-  if (pc < 0) return frag_invalid();
+  if (pc < 0)
+    return frag_invalid();
 
-  plist_t out; plist_init(&out);
-  if (!plist_push(&out, patch_field(pc, 0))) { plist_free(&out); perr(ps, "match: out of memory"); return frag_invalid(); }
+  plist_t out;
+  plist_init(&out);
+  if (!plist_push(&out, patch_field(pc, 0))) {
+    plist_free(&out);
+    perr(ps, "match: out of memory");
+    return frag_invalid();
+  }
   return frag_make(pc, out, false);
 }
 
 static frag_t parse_atom(parser_t *ps) {
-  if (at_end(ps)) return frag_invalid();
+  if (at_end(ps))
+    return frag_invalid();
 
   char c = peek(ps);
-  if (c == ')' || c == '|') return frag_invalid();
+  if (c == ')' || c == '|')
+    return frag_invalid();
 
   if (c == '(') {
     getc_ps(ps);
-    if (at_end(ps) || peek(ps) == ')') { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+    if (at_end(ps) || peek(ps) == ')') {
+      perr(ps, "match: pattern compile error");
+      return frag_invalid();
+    }
     frag_t inner = parse_alt(ps);
-    if (!inner.valid || !ps->ok) return frag_invalid();
-    if (at_end(ps) || peek(ps) != ')') { perr(ps, "match: pattern compile error"); plist_free(&inner.out); return frag_invalid(); }
+    if (!inner.valid || !ps->ok)
+      return frag_invalid();
+    if (at_end(ps) || peek(ps) != ')') {
+      perr(ps, "match: pattern compile error");
+      plist_free(&inner.out);
+      return frag_invalid();
+    }
     getc_ps(ps);
     return inner;
   }
 
-  if (c == '[') { getc_ps(ps); return parse_class(ps); }
+  if (c == '[') {
+    getc_ps(ps);
+    return parse_class(ps);
+  }
 
   if (c == '.') {
     getc_ps(ps);
-    inst_t ins; memset(&ins, 0, sizeof(ins));
-    ins.op = I_ANY; ins.x = -1;
+    inst_t ins;
+    memset(&ins, 0, sizeof(ins));
+    ins.op = I_ANY;
+    ins.x = -1;
     int pc = emit_inst(ps, ins);
-    if (pc < 0) return frag_invalid();
-    plist_t out; plist_init(&out);
-    if (!plist_push(&out, patch_field(pc, 0))) { plist_free(&out); perr(ps, "match: out of memory"); return frag_invalid(); }
+    if (pc < 0)
+      return frag_invalid();
+    plist_t out;
+    plist_init(&out);
+    if (!plist_push(&out, patch_field(pc, 0))) {
+      plist_free(&out);
+      perr(ps, "match: out of memory");
+      return frag_invalid();
+    }
     return frag_make(pc, out, false);
   }
 
   if (c == '\\') {
     getc_ps(ps);
     uint8_t lit = 0;
-    if (!parse_escape_outside(ps, &lit)) return frag_invalid();
-    inst_t ins; memset(&ins, 0, sizeof(ins));
-    ins.op = I_CHAR; ins.c = lit; ins.x = -1;
+    if (!parse_escape_outside(ps, &lit))
+      return frag_invalid();
+    inst_t ins;
+    memset(&ins, 0, sizeof(ins));
+    ins.op = I_CHAR;
+    ins.c = lit;
+    ins.x = -1;
     int pc = emit_inst(ps, ins);
-    if (pc < 0) return frag_invalid();
-    plist_t out; plist_init(&out);
-    if (!plist_push(&out, patch_field(pc, 0))) { plist_free(&out); perr(ps, "match: out of memory"); return frag_invalid(); }
+    if (pc < 0)
+      return frag_invalid();
+    plist_t out;
+    plist_init(&out);
+    if (!plist_push(&out, patch_field(pc, 0))) {
+      plist_free(&out);
+      perr(ps, "match: out of memory");
+      return frag_invalid();
+    }
     return frag_make(pc, out, false);
   }
 
-  if (is_quant(c)) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+  if (is_quant(c)) {
+    perr(ps, "match: pattern compile error");
+    return frag_invalid();
+  }
 
-  if (is_meta(c)) { perr(ps, "match: pattern compile error"); return frag_invalid(); }
+  if (is_meta(c)) {
+    perr(ps, "match: pattern compile error");
+    return frag_invalid();
+  }
 
   /* literal */
   getc_ps(ps);
-  inst_t ins; memset(&ins, 0, sizeof(ins));
-  ins.op = I_CHAR; ins.c = (uint8_t)c; ins.x = -1;
+  inst_t ins;
+  memset(&ins, 0, sizeof(ins));
+  ins.op = I_CHAR;
+  ins.c = (uint8_t)c;
+  ins.x = -1;
   int pc = emit_inst(ps, ins);
-  if (pc < 0) return frag_invalid();
-  plist_t out; plist_init(&out);
-  if (!plist_push(&out, patch_field(pc, 0))) { plist_free(&out); perr(ps, "match: out of memory"); return frag_invalid(); }
+  if (pc < 0)
+    return frag_invalid();
+  plist_t out;
+  plist_init(&out);
+  if (!plist_push(&out, patch_field(pc, 0))) {
+    plist_free(&out);
+    perr(ps, "match: out of memory");
+    return frag_invalid();
+  }
   return frag_make(pc, out, false);
 }
 
 static frag_t parse_repeat(parser_t *ps) {
   size_t save = ps->i;
   frag_t a = parse_atom(ps);
-  if (!a.valid) { ps->i = save; return frag_invalid(); }
+  if (!a.valid) {
+    ps->i = save;
+    return frag_invalid();
+  }
 
-  if (at_end(ps)) return a;
+  if (at_end(ps))
+    return a;
   char q = peek(ps);
-  if (!is_quant(q)) return a;
+  if (!is_quant(q))
+    return a;
 
   getc_ps(ps);
 
-  if (!at_end(ps) && is_quant(peek(ps))) { perr(ps, "match: pattern compile error"); plist_free(&a.out); return frag_invalid(); }
+  if (!at_end(ps) && is_quant(peek(ps))) {
+    perr(ps, "match: pattern compile error");
+    plist_free(&a.out);
+    return frag_invalid();
+  }
 
   if (q == '?') {
-    inst_t s; memset(&s, 0, sizeof(s));
-    s.op = I_SPLIT; s.x = a.start; s.y = -1;
+    inst_t s;
+    memset(&s, 0, sizeof(s));
+    s.op = I_SPLIT;
+    s.x = a.start;
+    s.y = -1;
     int pc = emit_inst(ps, s);
-    if (pc < 0) { plist_free(&a.out); return frag_invalid(); }
+    if (pc < 0) {
+      plist_free(&a.out);
+      return frag_invalid();
+    }
 
-    plist_t out; plist_init(&out);
+    plist_t out;
+    plist_init(&out);
     if (!plist_push(&out, patch_field(pc, 1)) || !plist_append(&out, &a.out)) {
-      plist_free(&out); plist_free(&a.out); perr(ps, "match: out of memory"); return frag_invalid();
+      plist_free(&out);
+      plist_free(&a.out);
+      perr(ps, "match: out of memory");
+      return frag_invalid();
     }
     plist_free(&a.out);
     return frag_make(pc, out, true);
   }
 
   if (q == '*') {
-    inst_t s; memset(&s, 0, sizeof(s));
-    s.op = I_SPLIT; s.x = a.start; s.y = -1;
+    inst_t s;
+    memset(&s, 0, sizeof(s));
+    s.op = I_SPLIT;
+    s.x = a.start;
+    s.y = -1;
     int pc = emit_inst(ps, s);
-    if (pc < 0) { plist_free(&a.out); return frag_invalid(); }
+    if (pc < 0) {
+      plist_free(&a.out);
+      return frag_invalid();
+    }
     patch(ps, &a.out, pc);
 
-    plist_t out; plist_init(&out);
-    if (!plist_push(&out, patch_field(pc, 1))) { plist_free(&out); plist_free(&a.out); perr(ps, "match: out of memory"); return frag_invalid(); }
+    plist_t out;
+    plist_init(&out);
+    if (!plist_push(&out, patch_field(pc, 1))) {
+      plist_free(&out);
+      plist_free(&a.out);
+      perr(ps, "match: out of memory");
+      return frag_invalid();
+    }
     plist_free(&a.out);
     return frag_make(pc, out, true);
   }
 
   /* '+' */
-  inst_t s; memset(&s, 0, sizeof(s));
-  s.op = I_SPLIT; s.x = a.start; s.y = -1;
+  inst_t s;
+  memset(&s, 0, sizeof(s));
+  s.op = I_SPLIT;
+  s.x = a.start;
+  s.y = -1;
   int pc = emit_inst(ps, s);
-  if (pc < 0) { plist_free(&a.out); return frag_invalid(); }
+  if (pc < 0) {
+    plist_free(&a.out);
+    return frag_invalid();
+  }
   patch(ps, &a.out, pc);
 
-  plist_t out; plist_init(&out);
-  if (!plist_push(&out, patch_field(pc, 1))) { plist_free(&out); plist_free(&a.out); perr(ps, "match: out of memory"); return frag_invalid(); }
+  plist_t out;
+  plist_init(&out);
+  if (!plist_push(&out, patch_field(pc, 1))) {
+    plist_free(&out);
+    plist_free(&a.out);
+    perr(ps, "match: out of memory");
+    return frag_invalid();
+  }
   plist_free(&a.out);
   return frag_make(a.start, out, false);
 }
@@ -409,12 +581,14 @@ static frag_t parse_concat(parser_t *ps) {
 
   while (!at_end(ps)) {
     char c = peek(ps);
-    if (c == '|' || c == ')') break;
+    if (c == '|' || c == ')')
+      break;
 
     size_t before = ps->i;
     frag_t r = parse_repeat(ps);
     if (!r.valid) {
-      if (ps->i == before) perr(ps, "match: pattern compile error");
+      if (ps->i == before)
+        perr(ps, "match: pattern compile error");
       break;
     }
 
@@ -429,7 +603,8 @@ static frag_t parse_concat(parser_t *ps) {
     }
   }
 
-  if (!have) return frag_invalid();
+  if (!have)
+    return frag_invalid();
   return first;
 }
 
@@ -444,19 +619,33 @@ static frag_t parse_alt(parser_t *ps) {
     frag_t right = parse_concat(ps);
     if (!left.valid || !right.valid) {
       perr(ps, "match: pattern compile error");
-      if (left.valid) plist_free(&left.out);
-      if (right.valid) plist_free(&right.out);
+      if (left.valid)
+        plist_free(&left.out);
+      if (right.valid)
+        plist_free(&right.out);
       return frag_invalid();
     }
 
-    inst_t s; memset(&s, 0, sizeof(s));
-    s.op = I_SPLIT; s.x = left.start; s.y = right.start;
+    inst_t s;
+    memset(&s, 0, sizeof(s));
+    s.op = I_SPLIT;
+    s.x = left.start;
+    s.y = right.start;
     int pc = emit_inst(ps, s);
-    if (pc < 0) { plist_free(&left.out); plist_free(&right.out); return frag_invalid(); }
+    if (pc < 0) {
+      plist_free(&left.out);
+      plist_free(&right.out);
+      return frag_invalid();
+    }
 
-    plist_t out; plist_init(&out);
+    plist_t out;
+    plist_init(&out);
     if (!plist_append(&out, &left.out) || !plist_append(&out, &right.out)) {
-      plist_free(&out); plist_free(&left.out); plist_free(&right.out); perr(ps, "match: out of memory"); return frag_invalid();
+      plist_free(&out);
+      plist_free(&left.out);
+      plist_free(&right.out);
+      perr(ps, "match: out of memory");
+      return frag_invalid();
     }
 
     plist_free(&left.out);
@@ -466,12 +655,20 @@ static frag_t parse_alt(parser_t *ps) {
 
   if (!saw_bar && !left.valid) {
     if (ps->allow_empty && ps->i == start_i) {
-      inst_t j; memset(&j, 0, sizeof(j));
-      j.op = I_JMP; j.x = -1;
+      inst_t j;
+      memset(&j, 0, sizeof(j));
+      j.op = I_JMP;
+      j.x = -1;
       int pc = emit_inst(ps, j);
-      if (pc < 0) return frag_invalid();
-      plist_t out; plist_init(&out);
-      if (!plist_push(&out, patch_field(pc, 0))) { plist_free(&out); perr(ps, "match: out of memory"); return frag_invalid(); }
+      if (pc < 0)
+        return frag_invalid();
+      plist_t out;
+      plist_init(&out);
+      if (!plist_push(&out, patch_field(pc, 0))) {
+        plist_free(&out);
+        perr(ps, "match: out of memory");
+        return frag_invalid();
+      }
       return frag_make(pc, out, true);
     }
     perr(ps, "match: pattern compile error");
@@ -484,17 +681,23 @@ static frag_t parse_alt(parser_t *ps) {
 /* global anchor detection */
 static bool is_escaped_at(const char *p, size_t idx) {
   size_t n = 0;
-  while (idx > 0 && p[idx - 1] == '\\') { n++; idx--; }
+  while (idx > 0 && p[idx - 1] == '\\') {
+    n++;
+    idx--;
+  }
   return (n & 1) == 1;
 }
 
-static void detect_global_anchors(const char *pat, size_t len,
-                                  bool *out_bol, bool *out_eol,
-                                  size_t *out_start, size_t *out_end) {
-  *out_bol = false; *out_eol = false;
-  *out_start = 0; *out_end = len;
+static void detect_global_anchors(const char *pat, size_t len, bool *out_bol,
+                                  bool *out_eol, size_t *out_start,
+                                  size_t *out_end) {
+  *out_bol = false;
+  *out_eol = false;
+  *out_start = 0;
+  *out_end = len;
 
-  if (len == 0) return;
+  if (len == 0)
+    return;
 
   if (pat[0] == '^' && !is_escaped_at(pat, 0)) {
     *out_bol = true;
@@ -505,9 +708,12 @@ static void detect_global_anchors(const char *pat, size_t len,
   size_t last = (size_t)-1;
   for (size_t i = 0; i < len; i++) {
     if (!is_escaped_at(pat, i)) {
-      if (pat[i] == '[') in_class = true;
-      else if (pat[i] == ']' && in_class) in_class = false;
-      if (!in_class) last = i;
+      if (pat[i] == '[')
+        in_class = true;
+      else if (pat[i] == ']' && in_class)
+        in_class = false;
+      if (!in_class)
+        last = i;
     }
   }
 
@@ -519,23 +725,34 @@ static void detect_global_anchors(const char *pat, size_t len,
 
 /* Public API */
 
-bool dc_regex_compile(dc_regex_t **out_re,
-                      const char *pattern,
+bool dc_regex_compile(dc_regex_t **out_re, const char *pattern,
                       char errbuf[256]) {
-  if (errbuf) errbuf[0] = '\0';
-  if (!out_re || !pattern) return false;
+  if (errbuf)
+    errbuf[0] = '\0';
+  if (!out_re || !pattern)
+    return false;
 
   size_t plen = strlen(pattern);
   if (plen > DC_REGEX_MAX_PATTERN_LEN) {
-    if (errbuf) snprintf(errbuf, 256, "match: pattern compile error");
+    if (errbuf)
+      snprintf(errbuf, 256, "match: pattern compile error");
     return false;
   }
 
   dc_regex_t *re = (dc_regex_t *)calloc(1, sizeof(dc_regex_t));
-  if (!re) { if (errbuf) snprintf(errbuf, 256, "match: out of memory"); return false; }
+  if (!re) {
+    if (errbuf)
+      snprintf(errbuf, 256, "match: out of memory");
+    return false;
+  }
 
   re->prog = (inst_t *)calloc(DC_REGEX_MAX_PROG_INSN, sizeof(inst_t));
-  if (!re->prog) { free(re); if (errbuf) snprintf(errbuf, 256, "match: out of memory"); return false; }
+  if (!re->prog) {
+    free(re);
+    if (errbuf)
+      snprintf(errbuf, 256, "match: out of memory");
+    return false;
+  }
 
   re->prog_len = 0;
   re->classes = NULL;
@@ -568,38 +785,69 @@ bool dc_regex_compile(dc_regex_t **out_re,
   frag_t f;
 
   if (sublen == 0) {
-    inst_t j; memset(&j, 0, sizeof(j));
-    j.op = I_JMP; j.x = -1;
+    inst_t j;
+    memset(&j, 0, sizeof(j));
+    j.op = I_JMP;
+    j.x = -1;
     int pc = emit_inst(&ps, j);
-    if (pc < 0) { dc_regex_free(re); return false; }
-    plist_t out; plist_init(&out);
-    if (!plist_push(&out, patch_field(pc, 0))) { plist_free(&out); dc_regex_free(re); if (errbuf) snprintf(errbuf, 256, "match: out of memory"); return false; }
+    if (pc < 0) {
+      dc_regex_free(re);
+      return false;
+    }
+    plist_t out;
+    plist_init(&out);
+    if (!plist_push(&out, patch_field(pc, 0))) {
+      plist_free(&out);
+      dc_regex_free(re);
+      if (errbuf)
+        snprintf(errbuf, 256, "match: out of memory");
+      return false;
+    }
     f = frag_make(pc, out, true);
   } else {
     f = parse_alt(&ps);
     if (!ps.ok || !f.valid || ps.i != ps.len) {
-      if (f.valid) plist_free(&f.out);
+      if (f.valid)
+        plist_free(&f.out);
       dc_regex_free(re);
-      if (errbuf && errbuf[0] == '\0') snprintf(errbuf, 256, "match: pattern compile error");
+      if (errbuf && errbuf[0] == '\0')
+        snprintf(errbuf, 256, "match: pattern compile error");
       return false;
     }
   }
 
   if (re->anchor_end) {
-    inst_t e; memset(&e, 0, sizeof(e));
-    e.op = I_EOL; e.x = -1;
+    inst_t e;
+    memset(&e, 0, sizeof(e));
+    e.op = I_EOL;
+    e.x = -1;
     int epc = emit_inst(&ps, e);
-    if (epc < 0) { plist_free(&f.out); dc_regex_free(re); return false; }
+    if (epc < 0) {
+      plist_free(&f.out);
+      dc_regex_free(re);
+      return false;
+    }
     patch(&ps, &f.out, epc);
     plist_free(&f.out);
     plist_init(&f.out);
-    if (!plist_push(&f.out, patch_field(epc, 0))) { plist_free(&f.out); dc_regex_free(re); if (errbuf) snprintf(errbuf, 256, "match: out of memory"); return false; }
+    if (!plist_push(&f.out, patch_field(epc, 0))) {
+      plist_free(&f.out);
+      dc_regex_free(re);
+      if (errbuf)
+        snprintf(errbuf, 256, "match: out of memory");
+      return false;
+    }
   }
 
-  inst_t m; memset(&m, 0, sizeof(m));
+  inst_t m;
+  memset(&m, 0, sizeof(m));
   m.op = I_MATCH;
   int mpc = emit_inst(&ps, m);
-  if (mpc < 0) { plist_free(&f.out); dc_regex_free(re); return false; }
+  if (mpc < 0) {
+    plist_free(&f.out);
+    dc_regex_free(re);
+    return false;
+  }
 
   patch(&ps, &f.out, mpc);
   plist_free(&f.out);
@@ -611,7 +859,8 @@ bool dc_regex_compile(dc_regex_t **out_re,
 }
 
 void dc_regex_free(dc_regex_t *re) {
-  if (!re) return;
+  if (!re)
+    return;
   free(re->prog);
   free(re->classes);
   free(re);
@@ -619,7 +868,10 @@ void dc_regex_free(dc_regex_t *re) {
 
 /* VM */
 
-typedef struct { int pc; size_t pos; } work_t;
+typedef struct {
+  int pc;
+  size_t pos;
+} work_t;
 
 typedef struct {
   int *pcs;
@@ -629,14 +881,19 @@ typedef struct {
 
 static bool slist_init(slist_t *l, int cap) {
   l->pcs = (int *)calloc((size_t)cap, sizeof(int));
-  if (!l->pcs) { l->n = 0; l->cap = 0; return false; }
+  if (!l->pcs) {
+    l->n = 0;
+    l->cap = 0;
+    return false;
+  }
   l->n = 0;
   l->cap = cap;
   return true;
 }
 
 static void slist_free(slist_t *l) {
-  if (!l) return;
+  if (!l)
+    return;
   free(l->pcs);
   l->pcs = NULL;
   l->n = 0;
@@ -644,97 +901,122 @@ static void slist_free(slist_t *l) {
 }
 
 static void slist_reset(slist_t *l) {
-  if (!l) return;
+  if (!l)
+    return;
   l->n = 0;
 }
 
 static bool slist_push(slist_t *l, int pc) {
-  if (l->n >= l->cap) return false;
+  if (l->n >= l->cap)
+    return false;
   l->pcs[l->n++] = pc;
   return true;
 }
 
 static bool list_has_match(const dc_regex_t *re, const slist_t *l) {
-  if (!re || !l) return false;
+  if (!re || !l)
+    return false;
   for (int i = 0; i < l->n; i++) {
     int pc = l->pcs[i];
-    if (pc < 0 || pc >= re->prog_len) continue;
-    if (re->prog[pc].op == I_MATCH) return true;
+    if (pc < 0 || pc >= re->prog_len)
+      continue;
+    if (re->prog[pc].op == I_MATCH)
+      return true;
   }
   return false;
 }
 
 /* add state via epsilon closure */
-static bool addstate(const dc_regex_t *re,
-                     slist_t *dst,
-                     uint32_t *mark,
-                     uint32_t gen,
-                     int pc,
-                     size_t pos,
-                     size_t subj_len,
-                     uint64_t *steps,
-                     bool *limit) {
-  if (!re || !dst) return false;
+static bool addstate(const dc_regex_t *re, slist_t *dst, uint32_t *mark,
+                     uint32_t gen, int pc, size_t pos, size_t subj_len,
+                     uint64_t *steps, bool *limit) {
+  if (!re || !dst)
+    return false;
 
   work_t stack[DC_REGEX_MAX_ACTIVE_STATES];
   int sp = 0;
 
-  if (sp >= DC_REGEX_MAX_ACTIVE_STATES) { *limit = true; return false; }
-  stack[sp++] = (work_t){ .pc = pc, .pos = pos };
+  if (sp >= DC_REGEX_MAX_ACTIVE_STATES) {
+    *limit = true;
+    return false;
+  }
+  stack[sp++] = (work_t){.pc = pc, .pos = pos};
 
   while (sp > 0) {
     work_t w = stack[--sp];
 
     (*steps)++;
-    if (*steps > DC_REGEX_MAX_STEPS) { *limit = true; return false; }
+    if (*steps > DC_REGEX_MAX_STEPS) {
+      *limit = true;
+      return false;
+    }
 
     int cpc = w.pc;
-    if (cpc < 0 || cpc >= re->prog_len) continue;
-    if (mark[cpc] == gen) continue;
+    if (cpc < 0 || cpc >= re->prog_len)
+      continue;
+    if (mark[cpc] == gen)
+      continue;
     mark[cpc] = gen;
 
     inst_t ins = re->prog[cpc];
     switch (ins.op) {
-      case I_JMP:
-        if (sp >= DC_REGEX_MAX_ACTIVE_STATES) { *limit = true; return false; }
-        stack[sp++] = (work_t){ .pc = ins.x, .pos = w.pos };
-        break;
-      case I_SPLIT:
-        if (sp + 2 >= DC_REGEX_MAX_ACTIVE_STATES) { *limit = true; return false; }
-        stack[sp++] = (work_t){ .pc = ins.x, .pos = w.pos };
-        stack[sp++] = (work_t){ .pc = ins.y, .pos = w.pos };
-        break;
-      case I_EOL:
-        if (w.pos == subj_len) {
-          if (sp >= DC_REGEX_MAX_ACTIVE_STATES) { *limit = true; return false; }
-          stack[sp++] = (work_t){ .pc = ins.x, .pos = w.pos };
+    case I_JMP:
+      if (sp >= DC_REGEX_MAX_ACTIVE_STATES) {
+        *limit = true;
+        return false;
+      }
+      stack[sp++] = (work_t){.pc = ins.x, .pos = w.pos};
+      break;
+    case I_SPLIT:
+      if (sp + 2 >= DC_REGEX_MAX_ACTIVE_STATES) {
+        *limit = true;
+        return false;
+      }
+      stack[sp++] = (work_t){.pc = ins.x, .pos = w.pos};
+      stack[sp++] = (work_t){.pc = ins.y, .pos = w.pos};
+      break;
+    case I_EOL:
+      if (w.pos == subj_len) {
+        if (sp >= DC_REGEX_MAX_ACTIVE_STATES) {
+          *limit = true;
+          return false;
         }
-        break;
-      default:
-        if (dst->n >= DC_REGEX_MAX_ACTIVE_STATES) { *limit = true; return false; }
-        if (!slist_push(dst, cpc)) { *limit = true; return false; }
-        break;
+        stack[sp++] = (work_t){.pc = ins.x, .pos = w.pos};
+      }
+      break;
+    default:
+      if (dst->n >= DC_REGEX_MAX_ACTIVE_STATES) {
+        *limit = true;
+        return false;
+      }
+      if (!slist_push(dst, cpc)) {
+        *limit = true;
+        return false;
+      }
+      break;
     }
   }
 
   return true;
 }
 
-bool dc_regex_match_line(const dc_regex_t *re,
-                         const uint8_t *subject,
-                         size_t subject_len,
-                         bool *exec_limit_exceeded) {
-  if (exec_limit_exceeded) *exec_limit_exceeded = false;
-  if (!re) return false;
+bool dc_regex_match_line(const dc_regex_t *re, const uint8_t *subject,
+                         size_t subject_len, bool *exec_limit_exceeded) {
+  if (exec_limit_exceeded)
+    *exec_limit_exceeded = false;
+  if (!re)
+    return false;
 
   uint32_t *mark = (uint32_t *)calloc((size_t)re->prog_len, sizeof(uint32_t));
-  if (!mark) return false;
+  if (!mark)
+    return false;
 
   slist_t clist, nlist;
   if (!slist_init(&clist, DC_REGEX_MAX_ACTIVE_STATES) ||
       !slist_init(&nlist, DC_REGEX_MAX_ACTIVE_STATES)) {
     free(mark);
-    if (clist.pcs) slist_free(&clist);
+    if (clist.pcs)
+      slist_free(&clist);
     return false;
   }
 
@@ -745,9 +1027,16 @@ bool dc_regex_match_line(const dc_regex_t *re,
   slist_reset(&clist);
   slist_reset(&nlist);
 
-  if (!addstate(re, &clist, mark, gen++, re->start_pc, 0, subject_len, &steps, &limit)) goto out;
+  if (!addstate(re, &clist, mark, gen++, re->start_pc, 0, subject_len, &steps,
+                &limit))
+    goto out;
 
-  if (list_has_match(re, &clist)) { slist_free(&clist); slist_free(&nlist); free(mark); return true; }
+  if (list_has_match(re, &clist)) {
+    slist_free(&clist);
+    slist_free(&nlist);
+    free(mark);
+    return true;
+  }
 
   if (re->anchor_start) {
     for (size_t i = 0; i < subject_len; i++) {
@@ -757,26 +1046,46 @@ bool dc_regex_match_line(const dc_regex_t *re,
         int pc = clist.pcs[si];
 
         steps++;
-        if (steps > DC_REGEX_MAX_STEPS) { limit = true; break; }
+        if (steps > DC_REGEX_MAX_STEPS) {
+          limit = true;
+          break;
+        }
 
         inst_t ins = re->prog[pc];
         uint8_t b = subject[i];
 
         if (ins.op == I_CHAR) {
-          if (ins.c == b) if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (ins.c == b)
+            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                          &steps, &limit))
+              break;
         } else if (ins.op == I_ANY) {
-          if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                        &steps, &limit))
+            break;
         } else if (ins.op == I_CLASS) {
-          if (ins.cls < (uint16_t)re->class_len && bitset_test(re->classes[ins.cls].bits, b))
-            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (ins.cls < (uint16_t)re->class_len &&
+              bitset_test(re->classes[ins.cls].bits, b))
+            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                          &steps, &limit))
+              break;
         }
       }
 
-      if (limit) break;
+      if (limit)
+        break;
       gen++;
-      slist_t tmp = clist; clist = nlist; nlist = tmp;
-      if (list_has_match(re, &clist)) { slist_free(&clist); slist_free(&nlist); free(mark); return true; }
-      if (clist.n == 0) break;
+      slist_t tmp = clist;
+      clist = nlist;
+      nlist = tmp;
+      if (list_has_match(re, &clist)) {
+        slist_free(&clist);
+        slist_free(&nlist);
+        free(mark);
+        return true;
+      }
+      if (clist.n == 0)
+        break;
     }
   } else {
     for (size_t i = 0; i < subject_len; i++) {
@@ -786,30 +1095,52 @@ bool dc_regex_match_line(const dc_regex_t *re,
         int pc = clist.pcs[si];
 
         steps++;
-        if (steps > DC_REGEX_MAX_STEPS) { limit = true; break; }
+        if (steps > DC_REGEX_MAX_STEPS) {
+          limit = true;
+          break;
+        }
 
         inst_t ins = re->prog[pc];
         uint8_t b = subject[i];
 
         if (ins.op == I_CHAR) {
-          if (ins.c == b) if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (ins.c == b)
+            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                          &steps, &limit))
+              break;
         } else if (ins.op == I_ANY) {
-          if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                        &steps, &limit))
+            break;
         } else if (ins.op == I_CLASS) {
-          if (ins.cls < (uint16_t)re->class_len && bitset_test(re->classes[ins.cls].bits, b))
-            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (ins.cls < (uint16_t)re->class_len &&
+              bitset_test(re->classes[ins.cls].bits, b))
+            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                          &steps, &limit))
+              break;
         }
       }
 
-      if (limit) break;
+      if (limit)
+        break;
 
       /* restart NFA at next position */
-      if (!addstate(re, &nlist, mark, gen, re->start_pc, i + 1, subject_len, &steps, &limit)) { /* may set limit */ }
-      if (limit) break;
+      if (!addstate(re, &nlist, mark, gen, re->start_pc, i + 1, subject_len,
+                    &steps, &limit)) { /* may set limit */
+      }
+      if (limit)
+        break;
 
       gen++;
-      slist_t tmp = clist; clist = nlist; nlist = tmp;
-      if (list_has_match(re, &clist)) { slist_free(&clist); slist_free(&nlist); free(mark); return true; }
+      slist_t tmp = clist;
+      clist = nlist;
+      nlist = tmp;
+      if (list_has_match(re, &clist)) {
+        slist_free(&clist);
+        slist_free(&nlist);
+        free(mark);
+        return true;
+      }
     }
   }
 
@@ -817,7 +1148,8 @@ out:
   slist_free(&clist);
   slist_free(&nlist);
   free(mark);
-  if (exec_limit_exceeded) *exec_limit_exceeded = limit;
+  if (exec_limit_exceeded)
+    *exec_limit_exceeded = limit;
   return false;
 }
 
@@ -828,33 +1160,37 @@ out:
  * - It does not change dc_regex_compile() nor dc_regex_match_line().
  * - It searches left-to-right from start_at.
  * - For the first start position that can reach MATCH, it returns the earliest
- *   end position (i.e., first time MATCH appears during the scan for that start).
+ *   end position (i.e., first time MATCH appears during the scan for that
+ * start).
  * - Zero-length matches are allowed (out_start==out_end).
  * -----------------------------------------------------------------------------
  */
-bool dc_regex_find_next(const dc_regex_t *re,
-                        const uint8_t *subject,
-                        size_t subject_len,
-                        size_t start_at,
-                        size_t *out_start,
-                        size_t *out_end,
-                        bool *exec_limit_exceeded) {
-  if (exec_limit_exceeded) *exec_limit_exceeded = false;
-  if (!re) return false;
-  if (!subject && subject_len != 0) return false;
-  if (start_at > subject_len) return false;
+bool dc_regex_find_next(const dc_regex_t *re, const uint8_t *subject,
+                        size_t subject_len, size_t start_at, size_t *out_start,
+                        size_t *out_end, bool *exec_limit_exceeded) {
+  if (exec_limit_exceeded)
+    *exec_limit_exceeded = false;
+  if (!re)
+    return false;
+  if (!subject && subject_len != 0)
+    return false;
+  if (start_at > subject_len)
+    return false;
 
   /* If pattern is anchored to start-of-line, only allow matching at 0. */
-  if (re->anchor_start && start_at != 0) return false;
+  if (re->anchor_start && start_at != 0)
+    return false;
 
   uint32_t *mark = (uint32_t *)calloc((size_t)re->prog_len, sizeof(uint32_t));
-  if (!mark) return false;
+  if (!mark)
+    return false;
 
   slist_t clist, nlist;
   if (!slist_init(&clist, DC_REGEX_MAX_ACTIVE_STATES) ||
       !slist_init(&nlist, DC_REGEX_MAX_ACTIVE_STATES)) {
     free(mark);
-    if (clist.pcs) slist_free(&clist);
+    if (clist.pcs)
+      slist_free(&clist);
     return false;
   }
 
@@ -864,21 +1200,27 @@ bool dc_regex_find_next(const dc_regex_t *re,
 
   size_t s_min = start_at;
   size_t s_max = subject_len;
-  if (re->anchor_start) { s_min = 0; s_max = 0; }
+  if (re->anchor_start) {
+    s_min = 0;
+    s_max = 0;
+  }
 
   for (size_t s = s_min; s <= s_max; s++) {
     slist_reset(&clist);
     slist_reset(&nlist);
 
-    if (!addstate(re, &clist, mark, gen++, re->start_pc, s, subject_len, &steps, &limit)) {
+    if (!addstate(re, &clist, mark, gen++, re->start_pc, s, subject_len, &steps,
+                  &limit)) {
       limit = true;
       break;
     }
 
     /* Zero-length match at s */
     if (list_has_match(re, &clist)) {
-      if (out_start) *out_start = s;
-      if (out_end) *out_end = s;
+      if (out_start)
+        *out_start = s;
+      if (out_end)
+        *out_end = s;
       slist_free(&clist);
       slist_free(&nlist);
       free(mark);
@@ -892,47 +1234,65 @@ bool dc_regex_find_next(const dc_regex_t *re,
         int pc = clist.pcs[si];
 
         steps++;
-        if (steps > DC_REGEX_MAX_STEPS) { limit = true; break; }
+        if (steps > DC_REGEX_MAX_STEPS) {
+          limit = true;
+          break;
+        }
 
         inst_t ins = re->prog[pc];
         uint8_t b = subject[i];
 
         if (ins.op == I_CHAR) {
           if (ins.c == b) {
-            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                          &steps, &limit))
+              break;
           }
         } else if (ins.op == I_ANY) {
-          if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                        &steps, &limit))
+            break;
         } else if (ins.op == I_CLASS) {
-          if (ins.cls < (uint16_t)re->class_len && bitset_test(re->classes[ins.cls].bits, b)) {
-            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len, &steps, &limit)) break;
+          if (ins.cls < (uint16_t)re->class_len &&
+              bitset_test(re->classes[ins.cls].bits, b)) {
+            if (!addstate(re, &nlist, mark, gen, ins.x, i + 1, subject_len,
+                          &steps, &limit))
+              break;
           }
         }
       }
 
-      if (limit) break;
+      if (limit)
+        break;
 
       gen++;
-      slist_t tmp = clist; clist = nlist; nlist = tmp;
+      slist_t tmp = clist;
+      clist = nlist;
+      nlist = tmp;
 
       if (list_has_match(re, &clist)) {
-        if (out_start) *out_start = s;
-        if (out_end) *out_end = i + 1;
+        if (out_start)
+          *out_start = s;
+        if (out_end)
+          *out_end = i + 1;
         slist_free(&clist);
         slist_free(&nlist);
         free(mark);
         return true;
       }
 
-      if (clist.n == 0) break;
+      if (clist.n == 0)
+        break;
     }
 
-    if (limit) break;
+    if (limit)
+      break;
   }
 
   slist_free(&clist);
   slist_free(&nlist);
   free(mark);
-  if (exec_limit_exceeded) *exec_limit_exceeded = limit;
+  if (exec_limit_exceeded)
+    *exec_limit_exceeded = limit;
   return false;
 }

--- a/src/diamondcore/split.c
+++ b/src/diamondcore/split.c
@@ -14,9 +14,12 @@ static inline bool is_ws(uint8_t c) {
           c == '\f');
 }
 
-size_t dc_split_ws(const uint8_t *line, size_t len, dc_field_view_t **out_fields) {
-  if (out_fields) *out_fields = NULL;
-  if (!out_fields || (!line && len != 0)) return 0;
+size_t dc_split_ws(const uint8_t *line, size_t len,
+                   dc_field_view_t **out_fields) {
+  if (out_fields)
+    *out_fields = NULL;
+  if (!out_fields || (!line && len != 0))
+    return 0;
 
   dc_field_view_t *v = NULL;
   size_t cap = 0;
@@ -25,14 +28,18 @@ size_t dc_split_ws(const uint8_t *line, size_t len, dc_field_view_t **out_fields
   size_t i = 0;
   while (i < len) {
     // Skip whitespace.
-    while (i < len && is_ws(line[i])) i++;
-    if (i >= len) break;
+    while (i < len && is_ws(line[i]))
+      i++;
+    if (i >= len)
+      break;
 
     // Start of field.
     size_t start = i;
-    while (i < len && !is_ws(line[i])) i++;
+    while (i < len && !is_ws(line[i]))
+      i++;
     size_t flen = i - start;
-    if (flen == 0) continue;
+    if (flen == 0)
+      continue;
 
     if (cnt == cap) {
       size_t ncap = cap ? cap * 2 : 8;
@@ -63,8 +70,10 @@ size_t dc_split_ws(const uint8_t *line, size_t len, dc_field_view_t **out_fields
 
 size_t dc_split_delim(const uint8_t *line, size_t len, uint8_t delim,
                       dc_field_view_t **out_fields) {
-  if (out_fields) *out_fields = NULL;
-  if (!out_fields || (!line && len != 0)) return 0;
+  if (out_fields)
+    *out_fields = NULL;
+  if (!out_fields || (!line && len != 0))
+    return 0;
 
   dc_field_view_t *v = NULL;
   size_t cap = 0;
@@ -79,7 +88,8 @@ size_t dc_split_delim(const uint8_t *line, size_t len, uint8_t delim,
   for (size_t i = 0; i <= len; i++) {
     bool at_end = (i == len);
     bool hit = (!at_end && line[i] == delim);
-    if (!at_end && !hit) continue;
+    if (!at_end && !hit)
+      continue;
 
     if (cnt == cap) {
       size_t ncap = cap ? cap * 2 : 8;

--- a/src/diamondcore/uint_parse.c
+++ b/src/diamondcore/uint_parse.c
@@ -4,41 +4,48 @@
 
 bool dc_parse_u64_dec_strict(const char *s, uint64_t *out, const char *label,
                              dc_error_t *err) {
-  if (!out || !err) return false;
+  if (!out || !err)
+    return false;
   dc_err_init(err);
 
   if (!s || !*s) {
-    dc_err_set(err, DC_ERR_USAGE, "invalid %s", (label && *label) ? label : "number");
+    dc_err_set(err, DC_ERR_USAGE, "invalid %s",
+               (label && *label) ? label : "number");
     return false;
   }
 
   /* No sign allowed. */
   if (*s == '+' || *s == '-') {
-    dc_err_set(err, DC_ERR_USAGE, "invalid %s", (label && *label) ? label : "number");
+    dc_err_set(err, DC_ERR_USAGE, "invalid %s",
+               (label && *label) ? label : "number");
     return false;
   }
 
   /* Digits only. */
   if (*s < '0' || *s > '9') {
-    dc_err_set(err, DC_ERR_USAGE, "invalid %s", (label && *label) ? label : "number");
+    dc_err_set(err, DC_ERR_USAGE, "invalid %s",
+               (label && *label) ? label : "number");
     return false;
   }
 
   /* Leading zeros forbidden unless exactly "0". */
   if (s[0] == '0' && s[1] != '\0') {
-    dc_err_set(err, DC_ERR_USAGE, "invalid %s", (label && *label) ? label : "number");
+    dc_err_set(err, DC_ERR_USAGE, "invalid %s",
+               (label && *label) ? label : "number");
     return false;
   }
 
   uint64_t v = 0;
   for (const char *p = s; *p; p++) {
     if (*p < '0' || *p > '9') {
-      dc_err_set(err, DC_ERR_USAGE, "invalid %s", (label && *label) ? label : "number");
+      dc_err_set(err, DC_ERR_USAGE, "invalid %s",
+                 (label && *label) ? label : "number");
       return false;
     }
     uint64_t d = (uint64_t)(*p - '0');
     if (v > (UINT64_MAX - d) / 10) {
-      dc_err_set(err, DC_ERR_USAGE, "invalid %s", (label && *label) ? label : "number");
+      dc_err_set(err, DC_ERR_USAGE, "invalid %s",
+                 (label && *label) ? label : "number");
       return false;
     }
     v = v * 10 + d;

--- a/src/diamondcore/usage_count.c
+++ b/src/diamondcore/usage_count.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 
 void dc_print_usage_count(FILE *out) {
-  fprintf(out,
-          "usage: count [--] [FILE...]\n"
-          "       count --help\n");
+  fprintf(out, "usage: count [--] [FILE...]\n"
+               "       count --help\n");
 }

--- a/src/diamondcore/usage_fields.c
+++ b/src/diamondcore/usage_fields.c
@@ -10,7 +10,8 @@
 #include <stdio.h>
 
 void dc_print_usage_fields(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: fields SPEC [FILE...]\n", out);
   fputs("       fields [--tsv] [-d DELIM] SPEC [--] [FILE...]\n", out);
   fputs("       fields --help\n", out);

--- a/src/diamondcore/usage_filter.c
+++ b/src/diamondcore/usage_filter.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 
 void dc_print_usage_filter(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: filter EXPR [--] [FILE...]\n", out);
   fputs("       filter --help\n", out);
 }

--- a/src/diamondcore/usage_lines.c
+++ b/src/diamondcore/usage_lines.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 
 void dc_print_usage_lines(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: lines SPEC [--] [FILE...]\n", out);
   fputs("       lines --help\n", out);
 }

--- a/src/diamondcore/usage_match.c
+++ b/src/diamondcore/usage_match.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 
 void dc_print_usage_match(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: match PATTERN [--] [FILE...]\n", out);
   fputs("       match --help\n", out);
 }

--- a/src/diamondcore/usage_replace.c
+++ b/src/diamondcore/usage_replace.c
@@ -4,7 +4,8 @@
 #include <stdio.h>
 
 void dc_print_usage_replace(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: replace [--literal] PATTERN REPLACEMENT [--] [FILE...]\n", out);
   fputs("       replace --help\n", out);
 }

--- a/src/diamondcore/usage_table.c
+++ b/src/diamondcore/usage_table.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 
 void dc_print_usage_table(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: table [--] [FILE...]\n", out);
   fputs("       table --help\n", out);
 }

--- a/src/diamondcore/usage_take.c
+++ b/src/diamondcore/usage_take.c
@@ -3,7 +3,8 @@
 #include <stdio.h>
 
 void dc_print_usage_take(FILE *out) {
-  if (!out) out = stdout;
+  if (!out)
+    out = stdout;
   fputs("usage: take N [S] [--] [FILE...]\n", out);
   fputs("       take --help\n", out);
 }

--- a/src/diamondcore/usage_trim.c
+++ b/src/diamondcore/usage_trim.c
@@ -3,9 +3,10 @@
 #include <stdio.h>
 
 void dc_print_usage_trim(FILE *out) {
-  fprintf(out,
-          "usage: trim [--] [FILE...]\n"
-          "       trim --help\n"
-          "\n"
-          "Remove leading and trailing ASCII whitespace from each input line.\n");
+  fprintf(
+      out,
+      "usage: trim [--] [FILE...]\n"
+      "       trim --help\n"
+      "\n"
+      "Remove leading and trailing ASCII whitespace from each input line.\n");
 }

--- a/src/include/dc_regex.h
+++ b/src/include/dc_regex.h
@@ -1,8 +1,8 @@
 #ifndef DC_REGEX_H
 #define DC_REGEX_H
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -10,25 +10,22 @@ extern "C" {
 #endif
 
 /* Spec resource limits */
-#define DC_REGEX_MAX_PATTERN_LEN      4096
-#define DC_REGEX_MAX_PROG_INSN        16384
-#define DC_REGEX_MAX_ACTIVE_STATES    8192
-#define DC_REGEX_MAX_STEPS            2000000
+#define DC_REGEX_MAX_PATTERN_LEN 4096
+#define DC_REGEX_MAX_PROG_INSN 16384
+#define DC_REGEX_MAX_ACTIVE_STATES 8192
+#define DC_REGEX_MAX_STEPS 2000000
 
 typedef struct dc_regex dc_regex_t;
 
 /* Compile PATTERN once; empty pattern is valid. */
-bool dc_regex_compile(dc_regex_t **out_re,
-                      const char *pattern,
+bool dc_regex_compile(dc_regex_t **out_re, const char *pattern,
                       char errbuf[256]);
 
 void dc_regex_free(dc_regex_t *re);
 
 /* Subject does NOT include newline. */
-bool dc_regex_match_line(const dc_regex_t *re,
-                         const uint8_t *subject,
-                         size_t subject_len,
-                         bool *exec_limit_exceeded);
+bool dc_regex_match_line(const dc_regex_t *re, const uint8_t *subject,
+                         size_t subject_len, bool *exec_limit_exceeded);
 
 /* Find next match in SUBJECT starting at START_AT.
  * Returns true and sets [*out_start, *out_end) on match.
@@ -36,13 +33,9 @@ bool dc_regex_match_line(const dc_regex_t *re,
  *
  * This does NOT support capturing; it finds only the overall match span.
  */
-bool dc_regex_find_next(const dc_regex_t *re,
-                        const uint8_t *subject,
-                        size_t subject_len,
-                        size_t start_at,
-                        size_t *out_start,
-                        size_t *out_end,
-                        bool *exec_limit_exceeded);
+bool dc_regex_find_next(const dc_regex_t *re, const uint8_t *subject,
+                        size_t subject_len, size_t start_at, size_t *out_start,
+                        size_t *out_end, bool *exec_limit_exceeded);
 
 #ifdef __cplusplus
 }

--- a/src/include/diamondcore.h
+++ b/src/include/diamondcore.h
@@ -1,5 +1,6 @@
 /* src/include/diamondcore.h */
-/* DROP-IN: restore original header structure and add replace declarations only */
+/* DROP-IN: restore original header structure and add replace declarations only
+ */
 
 #ifndef DIAMONDCORE_H
 #define DIAMONDCORE_H
@@ -78,7 +79,7 @@ void dc_print_help_trim(FILE *out);
 void dc_print_help_lines(FILE *out);
 void dc_print_help_fields(FILE *out);
 void dc_print_help_match(FILE *out);
-void dc_print_help_replace(FILE *out);  /* NEW */
+void dc_print_help_replace(FILE *out); /* NEW */
 void dc_print_help_take(FILE *out);
 void dc_print_help_count(FILE *out);
 void dc_print_help_table(FILE *out);
@@ -93,7 +94,8 @@ void dc_print_help_common_sigpipe(FILE *out);
  * - what: header label (e.g., "SPEC")
  * - scope: one-line scope description (may be "")
  */
-void dc_print_help_common_range_spec(FILE *out, const char *what, const char *scope);
+void dc_print_help_common_range_spec(FILE *out, const char *what,
+                                     const char *scope);
 
 /* =============================================================================
  * Strict unsigned base-10 integer parsing.
@@ -103,7 +105,8 @@ void dc_print_help_common_range_spec(FILE *out, const char *what, const char *sc
  * - no leading zeros unless exactly "0"
  * - must fit in uint64_t
  *
- * On failure sets err->code=DC_ERR_USAGE and a short message (e.g. "invalid N").
+ * On failure sets err->code=DC_ERR_USAGE and a short message (e.g. "invalid
+ * N").
  * =============================================================================
  */
 bool dc_parse_u64_dec_strict(const char *s, uint64_t *out, const char *label,
@@ -122,7 +125,8 @@ void dc_sel_free(dc_sel_t *sel);
  * Line reader (streaming, bytewise)
  * =============================================================================
  */
-dc_line_reader_t *dc_lr_open(char *const *files, size_t file_count, dc_error_t *err);
+dc_line_reader_t *dc_lr_open(char *const *files, size_t file_count,
+                             dc_error_t *err);
 bool dc_lr_next(dc_line_reader_t *lr, dc_line_view_t *out, dc_error_t *err);
 void dc_lr_close(dc_line_reader_t *lr);
 
@@ -133,19 +137,20 @@ void dc_lr_close(dc_line_reader_t *lr);
 
 /* Split a line into non-empty fields separated by ASCII whitespace.
  * - Returns number of fields.
- * - On success, *out_fields points to heap array of views into line buffer (no copies).
- *   Caller free().
+ * - On success, *out_fields points to heap array of views into line buffer (no
+ * copies). Caller free().
  * - If no fields, returns 0 and sets *out_fields = NULL.
  * - On allocation failure, returns (size_t)-1 and sets *out_fields = NULL.
  * - Trailing '\n' is treated as whitespace.
  */
-size_t dc_split_ws(const uint8_t *line, size_t len, dc_field_view_t **out_fields);
+size_t dc_split_ws(const uint8_t *line, size_t len,
+                   dc_field_view_t **out_fields);
 
 /* Split a line into fields separated by a single byte delimiter.
  * - Preserves empty fields (consecutive/leading/trailing delimiters).
  * - Returns number of fields (>=1 for any line, including empty).
- * - On success, *out_fields points to heap array of views into line buffer (no copies).
- *   Caller free().
+ * - On success, *out_fields points to heap array of views into line buffer (no
+ * copies). Caller free().
  * - On allocation failure, returns (size_t)-1 and sets *out_fields = NULL.
  */
 size_t dc_split_delim(const uint8_t *line, size_t len, uint8_t delim,


### PR DESCRIPTION
## Summary
- apply a repository-wide `clang-format` normalization across the `src/` files covered by `FORMAT_SRCS`
- make `make format-check` pass on the existing baseline
- keep the change mechanical only, with no intended behavior changes

## Why
`make format-check` runs `clang-format --dry-run --Werror` across the `src/` tree, and the current baseline fails in 38 of 39 checked files. This PR normalizes that baseline so the formatting gate can pass consistently.

## Validation
- `make format-check`
- `make test`
- `make cppcheck`

## Notes
- scope is limited to formatter output in `src/**/*.c` and `src/**/*.h`
- no docs, workflows, or test expectations were changed

Closes #10